### PR TITLE
Set correct bundle id and team for the project

### DIFF
--- a/push-notifications-ios/push-notifications-ios.xcodeproj/project.pbxproj
+++ b/push-notifications-ios/push-notifications-ios.xcodeproj/project.pbxproj
@@ -314,7 +314,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "push-notifications-ios/push-notifications-ios.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 7ZMER4V3FM;
+				DEVELOPMENT_TEAM = H7FL434D9W;
 				INFOPLIST_FILE = "push-notifications-ios/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -331,7 +331,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "push-notifications-ios/push-notifications-ios.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 7ZMER4V3FM;
+				DEVELOPMENT_TEAM = H7FL434D9W;
 				INFOPLIST_FILE = "push-notifications-ios/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/push-notifications-mac/push-notifications-mac.xcodeproj/project.pbxproj
+++ b/push-notifications-mac/push-notifications-mac.xcodeproj/project.pbxproj
@@ -300,10 +300,10 @@
 				CODE_SIGN_ENTITLEMENTS = "push-notifications-mac/push_notifications_mac.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 7ZMER4V3FM;
+				DEVELOPMENT_TEAM = H7FL434D9W;
 				INFOPLIST_FILE = "push-notifications-mac/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.pusher.push-notifications-mac";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.pusher.push-notifications-macos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 			};
@@ -316,10 +316,10 @@
 				CODE_SIGN_ENTITLEMENTS = "push-notifications-mac/push_notifications_mac.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 7ZMER4V3FM;
+				DEVELOPMENT_TEAM = H7FL434D9W;
 				INFOPLIST_FILE = "push-notifications-mac/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.pusher.push-notifications-mac";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.pusher.push-notifications-macos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 			};


### PR DESCRIPTION
### What?

Fixed project settings for:
`push-notifications-mac`: bundle identifier and team id.
`push-notifications-ios`: team id.

----
CC @pusher/mobile
