### PR TITLE
Detect where the start function is being called from

### DIFF
--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -22,6 +22,14 @@ import Foundation
      */
     /// - Tag: start
     @objc public func start(instanceId: String) {
+        // Detect from where the function is being called
+        let wasCalledFromCorrectLocation = Thread.callStackSymbols.contains { stack in
+            return stack.contains("didFinishLaunchingWith") || stack.contains("applicationDidFinishLaunching")
+        }
+        if (!wasCalledFromCorrectLocation) {
+            print("Warning: You should call `pushNotifications.start` from the `AppDelegate.didFinishLaunchingWith`")
+        }
+
         do {
             try Instance.persist(instanceId)
         } catch PusherAlreadyRegisteredError.instanceId(let errorMessage) {


### PR DESCRIPTION
### What?

Detect where the start function is being called from.

#### Why?

We want it to always be called from the start of the app.

----
CC @pusher/mobile
