### PR TITLE
Add SDK version header value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/push-notifications-swift/compare/0.10.5...HEAD)
 
+### Added
+
+- `X-Pusher-Library` HTTP header field.
+
 ## [0.10.5](https://github.com/pusher/push-notifications-swift/compare/0.10.4...0.10.5) - 2018-03-20
 
 ### Added

--- a/Sources/NetworkService.swift
+++ b/Sources/NetworkService.swift
@@ -100,6 +100,7 @@ struct NetworkService: PushNotificationsNetworkable {
     private func setRequest(url: URL, httpMethod: HTTPMethod, body: Data? = nil) -> URLRequest {
         var request = URLRequest(url: url)
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("push-notifications-swift \(SDK.version)", forHTTPHeaderField: "x-pusher-library")
         request.httpMethod = httpMethod.rawValue
         request.httpBody = body
 

--- a/Sources/NetworkService.swift
+++ b/Sources/NetworkService.swift
@@ -100,7 +100,7 @@ struct NetworkService: PushNotificationsNetworkable {
     private func setRequest(url: URL, httpMethod: HTTPMethod, body: Data? = nil) -> URLRequest {
         var request = URLRequest(url: url)
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.addValue("push-notifications-swift \(SDK.version)", forHTTPHeaderField: "x-pusher-library")
+        request.addValue("push-notifications-swift \(SDK.version)", forHTTPHeaderField: "X-Pusher-Library")
         request.httpMethod = httpMethod.rawValue
         request.httpBody = body
 


### PR DESCRIPTION
### What?

Add SDK version header field.

Example:
```
(lldb) po request.allHTTPHeaderFields
▿ Optional<Dictionary<String, String>>
  ▿ some : 2 elements
    ▿ 0 : 2 elements
      - key : "Content-Type"
      - value : "application/json"
    ▿ 1 : 2 elements
      - key : "x-pusher-library"
      - value : "push-notifications-swift 0.10.5"
```

----
CC @pusher/mobile
