### PR TITLE
Remote Notification Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/push-notifications-swift/compare/0.10.6...HEAD)
+## [Unreleased](https://github.com/pusher/push-notifications-swift/compare/0.10.7...HEAD)
+
+## [0.10.7](https://github.com/pusher/push-notifications-swift/compare/0.10.5...0.10.6) - 2018-04-24
 
 ### Added
 
 - Applied recommended settings by Xcode 9.3 to the example projects.
+- Ability to ignore Pusher related remote notifications. PR: [#60](https://github.com/pusher/push-notifications-swift/pull/60)
 
 ## [0.10.6](https://github.com/pusher/push-notifications-swift/compare/0.10.5...0.10.6) - 2018-04-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/push-notifications-swift/compare/0.10.7...HEAD)
 
-## [0.10.7](https://github.com/pusher/push-notifications-swift/compare/0.10.5...0.10.6) - 2018-04-24
+## [0.10.7](https://github.com/pusher/push-notifications-swift/compare/0.10.6...0.10.7) - 2018-04-24
 
 ### Added
 

--- a/PushNotifications.podspec
+++ b/PushNotifications.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PushNotifications'
-  s.version          = '0.10.6'
+  s.version          = '0.10.7'
   s.summary          = 'PushNotifications SDK'
   s.homepage         = 'https://github.com/pusher/push-notifications-swift'
   s.license          = 'MIT'

--- a/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
+++ b/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		A1E78E312020AEF400DD94B2 /* Register.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E78E302020AEF400DD94B2 /* Register.swift */; };
 		A1E8000A201A213000467EB9 /* ReportEventType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E80009201A213000467EB9 /* ReportEventType.swift */; };
 		A1E80015201A3DAC00467EB9 /* PublishId.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E80013201A3DAC00467EB9 /* PublishId.swift */; };
+		A1EFF5C9207B7E78006C3004 /* RemoteNotificationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1EFF5C8207B7E78006C3004 /* RemoteNotificationType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -113,6 +114,7 @@
 		A1E80009201A213000467EB9 /* ReportEventType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReportEventType.swift; path = ../../Sources/ReportEventType.swift; sourceTree = "<group>"; };
 		A1E80013201A3DAC00467EB9 /* PublishId.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PublishId.swift; path = ../../Sources/PublishId.swift; sourceTree = "<group>"; };
 		A1ED00141F9E392700A029F2 /* PushNotificationsTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PushNotificationsTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		A1EFF5C8207B7E78006C3004 /* RemoteNotificationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RemoteNotificationType.swift; path = ../../Sources/RemoteNotificationType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -192,6 +194,7 @@
 				A1E80009201A213000467EB9 /* ReportEventType.swift */,
 				A140FFD62020C5E600931AF6 /* SDK.swift */,
 				A1DAD62D2020CAE7001497B5 /* SystemVersion.swift */,
+				A1EFF5C8207B7E78006C3004 /* RemoteNotificationType.swift */,
 			);
 			path = PushNotifications;
 			sourceTree = "<group>";
@@ -359,6 +362,7 @@
 				A140FFD32020BECF00931AF6 /* Interests.swift in Sources */,
 				A19ECF831FCF099200688DAF /* InterestPersistable.swift in Sources */,
 				A1DAD62E2020CAE7001497B5 /* SystemVersion.swift in Sources */,
+				A1EFF5C9207B7E78006C3004 /* RemoteNotificationType.swift in Sources */,
 				A19ECF841FCF099200688DAF /* PersistenceService.swift in Sources */,
 				A10552ED2028A934001E45D1 /* Metadata.swift in Sources */,
 				A144AB521F9E3DA3009F0040 /* NetworkService.swift in Sources */,

--- a/PushNotifications/PushNotifications/Info.plist
+++ b/PushNotifications/PushNotifications/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.6</string>
+	<string>0.10.7</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/PushNotifications/PushNotificationsTests/Info.plist
+++ b/PushNotifications/PushNotificationsTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.6</string>
+	<string>0.10.7</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/Sources/EventTypeHandler.swift
+++ b/Sources/EventTypeHandler.swift
@@ -74,6 +74,6 @@ struct EventTypeHandler {
             let pusher = data["pusher"] as? Dictionary<String, Any>
         else { return .ShouldProcess }
 
-        return pusher["isInternalOnly"] != nil ? .ShouldIgnore : .ShouldProcess
+        return pusher["userShouldIgnore"] != nil ? .ShouldIgnore : .ShouldProcess
     }
 }

--- a/Sources/EventTypeHandler.swift
+++ b/Sources/EventTypeHandler.swift
@@ -67,4 +67,13 @@ struct EventTypeHandler {
         // Returns `true` if there is any additional information provided.
         return data.count > 1
     }
+
+    static func isInternalNotification(_ userInfo: [AnyHashable: Any]) -> RemoteNotificationType {
+        guard
+            let data = userInfo["data"] as? Dictionary<String, Any>,
+            let pusher = data["pusher"] as? Dictionary<String, Any>
+        else { return .Other }
+
+        return pusher["isInternalOnly"] != nil ? .Internal : .Other
+    }
 }

--- a/Sources/EventTypeHandler.swift
+++ b/Sources/EventTypeHandler.swift
@@ -68,7 +68,7 @@ struct EventTypeHandler {
         return data.count > 1
     }
 
-    static func isInternalNotification(_ userInfo: [AnyHashable: Any]) -> RemoteNotificationType {
+    static func getRemoteNotificationType(_ userInfo: [AnyHashable: Any]) -> RemoteNotificationType {
         guard
             let data = userInfo["data"] as? Dictionary<String, Any>,
             let pusher = data["pusher"] as? Dictionary<String, Any>

--- a/Sources/EventTypeHandler.swift
+++ b/Sources/EventTypeHandler.swift
@@ -72,8 +72,8 @@ struct EventTypeHandler {
         guard
             let data = userInfo["data"] as? Dictionary<String, Any>,
             let pusher = data["pusher"] as? Dictionary<String, Any>
-        else { return .Other }
+        else { return .ShouldProcess }
 
-        return pusher["isInternalOnly"] != nil ? .Internal : .Other
+        return pusher["isInternalOnly"] != nil ? .ShouldIgnore : .ShouldProcess
     }
 }

--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -258,8 +258,8 @@ import Foundation
      - Parameter userInfo: Remote Notification payload.
      */
     /// - Tag: handleNotification
-    @objc public func handleNotification(userInfo: [AnyHashable: Any]) {
-        guard FeatureFlags.DeliveryTrackingEnabled else { return }
+    @objc public func handleNotification(userInfo: [AnyHashable: Any]) -> RemoteNotificationType {
+        guard FeatureFlags.DeliveryTrackingEnabled else { return .Other }
 
         #if os(iOS)
             let applicationState = UIApplication.shared.applicationState
@@ -280,6 +280,8 @@ import Foundation
             let networkService: PushNotificationsNetworkable = NetworkService(url: url, session: self.session)
             networkService.track(eventType: eventType, completion: { (_, _) in })
         }
+
+        return EventTypeHandler.isInternalNotification(userInfo)
     }
 
     private func validateInterestName(_ interest: String) -> Bool {

--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -259,7 +259,7 @@ import Foundation
      */
     /// - Tag: handleNotification
     @objc public func handleNotification(userInfo: [AnyHashable: Any]) -> RemoteNotificationType {
-        guard FeatureFlags.DeliveryTrackingEnabled else { return .Other }
+        guard FeatureFlags.DeliveryTrackingEnabled else { return .ShouldProcess }
 
         #if os(iOS)
             let applicationState = UIApplication.shared.applicationState

--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -281,7 +281,7 @@ import Foundation
             networkService.track(eventType: eventType, completion: { (_, _) in })
         }
 
-        return EventTypeHandler.isInternalNotification(userInfo)
+        return EventTypeHandler.getRemoteNotificationType(userInfo)
     }
 
     private func validateInterestName(_ interest: String) -> Bool {

--- a/Sources/RemoteNotificationType.swift
+++ b/Sources/RemoteNotificationType.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+@objc public enum RemoteNotificationType: Int {
+    case Internal
+    case Other
+}

--- a/Sources/RemoteNotificationType.swift
+++ b/Sources/RemoteNotificationType.swift
@@ -1,6 +1,6 @@
 import Foundation
 
 @objc public enum RemoteNotificationType: Int {
-    case Internal
-    case Other
+    case ShouldIgnore
+    case ShouldProcess
 }

--- a/Sources/SDK.swift
+++ b/Sources/SDK.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 struct SDK {
-    static let version = "0.10.6"
+    static let version = "0.10.7"
 }

--- a/Tests/EventTypeHandlerTests.swift
+++ b/Tests/EventTypeHandlerTests.swift
@@ -81,7 +81,7 @@ class EventTypeHandlerTests: XCTestCase {
     #endif
 
     func testItIsInternalNotification() {
-        let userInfo = ["aps" : ["alert": ["title": "Hello", "body": "Hello, world!"], "content-available": 1], "data": ["pusher": ["publishId": "pubid-33f3f68e-b0c5-438f-b50f-fae93f6c48df", "isInternalOnly": true]]]
+        let userInfo = ["aps" : ["alert": ["title": "Hello", "body": "Hello, world!"], "content-available": 1], "data": ["pusher": ["publishId": "pubid-33f3f68e-b0c5-438f-b50f-fae93f6c48df", "userShouldIgnore": true]]]
 
         let remoteNotificationType = EventTypeHandler.getRemoteNotificationType(userInfo)
         XCTAssertTrue(remoteNotificationType == .ShouldIgnore)

--- a/Tests/EventTypeHandlerTests.swift
+++ b/Tests/EventTypeHandlerTests.swift
@@ -79,4 +79,18 @@ class EventTypeHandlerTests: XCTestCase {
         XCTAssertTrue(eventType.event == "Open")
     }
     #endif
+
+    func testItIsInternalNotification() {
+        let userInfo = ["aps" : ["alert": ["title": "Hello", "body": "Hello, world!"], "content-available": 1], "data": ["pusher": ["publishId": "pubid-33f3f68e-b0c5-438f-b50f-fae93f6c48df", "isInternalOnly": true]]]
+
+        let remoteNotificationType = EventTypeHandler.isInternalNotification(userInfo)
+        XCTAssertTrue(remoteNotificationType == .Internal)
+    }
+
+    func testItIsNotInternalNotification() {
+        let userInfo = ["aps" : ["alert": ["title": "Hello", "body": "Hello, world!"], "content-available": 1], "data": ["pusher": ["publishId": "pubid-33f3f68e-b0c5-438f-b50f-fae93f6c48df"]]]
+
+        let remoteNotificationType = EventTypeHandler.isInternalNotification(userInfo)
+        XCTAssertTrue(remoteNotificationType == .Other)
+    }
 }

--- a/Tests/EventTypeHandlerTests.swift
+++ b/Tests/EventTypeHandlerTests.swift
@@ -83,14 +83,14 @@ class EventTypeHandlerTests: XCTestCase {
     func testItIsInternalNotification() {
         let userInfo = ["aps" : ["alert": ["title": "Hello", "body": "Hello, world!"], "content-available": 1], "data": ["pusher": ["publishId": "pubid-33f3f68e-b0c5-438f-b50f-fae93f6c48df", "isInternalOnly": true]]]
 
-        let remoteNotificationType = EventTypeHandler.isInternalNotification(userInfo)
+        let remoteNotificationType = EventTypeHandler.getRemoteNotificationType(userInfo)
         XCTAssertTrue(remoteNotificationType == .ShouldIgnore)
     }
 
     func testItIsNotInternalNotification() {
         let userInfo = ["aps" : ["alert": ["title": "Hello", "body": "Hello, world!"], "content-available": 1], "data": ["pusher": ["publishId": "pubid-33f3f68e-b0c5-438f-b50f-fae93f6c48df"]]]
 
-        let remoteNotificationType = EventTypeHandler.isInternalNotification(userInfo)
+        let remoteNotificationType = EventTypeHandler.getRemoteNotificationType(userInfo)
         XCTAssertTrue(remoteNotificationType == .ShouldProcess)
     }
 }

--- a/Tests/EventTypeHandlerTests.swift
+++ b/Tests/EventTypeHandlerTests.swift
@@ -84,13 +84,13 @@ class EventTypeHandlerTests: XCTestCase {
         let userInfo = ["aps" : ["alert": ["title": "Hello", "body": "Hello, world!"], "content-available": 1], "data": ["pusher": ["publishId": "pubid-33f3f68e-b0c5-438f-b50f-fae93f6c48df", "isInternalOnly": true]]]
 
         let remoteNotificationType = EventTypeHandler.isInternalNotification(userInfo)
-        XCTAssertTrue(remoteNotificationType == .Internal)
+        XCTAssertTrue(remoteNotificationType == .ShouldIgnore)
     }
 
     func testItIsNotInternalNotification() {
         let userInfo = ["aps" : ["alert": ["title": "Hello", "body": "Hello, world!"], "content-available": 1], "data": ["pusher": ["publishId": "pubid-33f3f68e-b0c5-438f-b50f-fae93f6c48df"]]]
 
         let remoteNotificationType = EventTypeHandler.isInternalNotification(userInfo)
-        XCTAssertTrue(remoteNotificationType == .Other)
+        XCTAssertTrue(remoteNotificationType == .ShouldProcess)
     }
 }

--- a/Tests/MetadataTests.swift
+++ b/Tests/MetadataTests.swift
@@ -117,6 +117,6 @@ class MetadataTests: XCTestCase {
         XCTAssertNotNil(metadata.sdkVersion)
         XCTAssertNotNil(metadata.iosVersion)
         XCTAssertNotNil(metadata.macosVersion)
-        XCTAssert(metadata.sdkVersion == "0.10.6")
+        XCTAssert(metadata.sdkVersion == "0.10.7")
     }
 }

--- a/Tests/SDKTests.swift
+++ b/Tests/SDKTests.swift
@@ -5,6 +5,6 @@ class SDKTests: XCTestCase {
     func testVersionModel() {
         let version = SDK.version
         XCTAssertNotNil(version)
-        XCTAssertEqual(version, "0.10.6")
+        XCTAssertEqual(version, "0.10.7")
     }
 }


### PR DESCRIPTION
### What?

Usage:
```
// Example userInfo payload.
let userInfo = ["aps" : ["alert": ["title": "Hello", "body": "Hello, world!"], "content-available": 1], "data": ["pusher": ["publishId": "pubid-33f3f68e-b0c5-438f-b50f-fae93f6c48df", "userShouldIgnore": true]]]

// Get remote notification type.
// `handleNotification` now returns notification type: `RemoteNotificationType` which can be either `ShouldIgnore` or `ShouldProcess`.
let remoteNotificationType = self.pushNotifications.handleNotification(userInfo: userInfo)
if remoteNotificationType == .ShouldIgnore {
    return
}
```
----
CC @pusher/mobile