### PR TITLE
Minor improvements

### DIFF
--- a/Sources/NetworkService.swift
+++ b/Sources/NetworkService.swift
@@ -5,8 +5,6 @@ struct NetworkService: PushNotificationsNetworkable {
     let url: URL
     let session: URLSession
 
-    typealias NetworkCompletionHandler = (_ response: NetworkResponse) -> Void
-
     // MARK: PushNotificationsNetworkable
     func register(deviceToken: Data, instanceId: String, completion: @escaping CompletionHandler<Device>) {
         let deviceTokenString = deviceToken.hexadecimalRepresentation()
@@ -108,7 +106,7 @@ struct NetworkService: PushNotificationsNetworkable {
     }
 
     // MARK: Networking Layer
-    private func networkRequest(_ request: URLRequest, session: URLSession, completion: @escaping NetworkCompletionHandler) {
+    private func networkRequest(_ request: URLRequest, session: URLSession, completion: @escaping (_ response: NetworkResponse) -> Void) {
         session.dataTask(with: request, completionHandler: { (data, response, error) in
             guard
                 let data = data,

--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -304,6 +304,7 @@ import Foundation
      - Parameter userInfo: Remote Notification payload.
      */
     /// - Tag: handleNotification
+    @discardableResult
     @objc public func handleNotification(userInfo: [AnyHashable: Any]) -> RemoteNotificationType {
         guard FeatureFlags.DeliveryTrackingEnabled else { return .ShouldProcess }
 


### PR DESCRIPTION
### What?

- I've removed `NetworkCompletionHandler` typealias since it's used just in one place and I think that it's not needed anymore.

- `handleNotification` method returns `RemoteNotificationType`. Since it's not obligatory to handle the return value I've added `discardableResult` attribute which will supress the warning in the Xcode.

----
CC @pusher/mobile
