### PR TITLE
Implement retry strategy for failed HTTP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/push-notifications-swift/compare/0.10.10...HEAD)
 
+### Added
+
+- Retry strategy with exponential backoff - if the HTTP request fails, SDK will retry that request.
+
 ## [0.10.10](https://github.com/pusher/push-notifications-swift/compare/0.10.9...0.10.10) - 2018-06-25
 
-## Added
+### Added
 
 - `interestsSetDidChange(interests:)` will be called when interests set changes.
 

--- a/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
+++ b/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
@@ -22,7 +22,6 @@
 		A140FFD32020BECF00931AF6 /* Interests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A140FFD22020BECF00931AF6 /* Interests.swift */; };
 		A140FFD72020C5E600931AF6 /* SDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = A140FFD62020C5E600931AF6 /* SDK.swift */; };
 		A144AB4C1F9E3DA3009F0040 /* DeviceTokenHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A144AB441F9E3DA2009F0040 /* DeviceTokenHelper.swift */; };
-		A144AB4D1F9E3DA3009F0040 /* NetworkResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A144AB451F9E3DA2009F0040 /* NetworkResponse.swift */; };
 		A144AB4E1F9E3DA3009F0040 /* PushNotificationsNetworkable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A144AB461F9E3DA2009F0040 /* PushNotificationsNetworkable.swift */; };
 		A144AB4F1F9E3DA3009F0040 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = A144AB471F9E3DA2009F0040 /* Device.swift */; };
 		A144AB501F9E3DA3009F0040 /* PushNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = A144AB481F9E3DA2009F0040 /* PushNotifications.swift */; };
@@ -81,7 +80,6 @@
 		A140FFD22020BECF00931AF6 /* Interests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Interests.swift; path = ../../Sources/Interests.swift; sourceTree = "<group>"; };
 		A140FFD62020C5E600931AF6 /* SDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SDK.swift; path = ../../Sources/SDK.swift; sourceTree = "<group>"; };
 		A144AB441F9E3DA2009F0040 /* DeviceTokenHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DeviceTokenHelper.swift; path = ../../Sources/DeviceTokenHelper.swift; sourceTree = "<group>"; };
-		A144AB451F9E3DA2009F0040 /* NetworkResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NetworkResponse.swift; path = ../../Sources/NetworkResponse.swift; sourceTree = "<group>"; };
 		A144AB461F9E3DA2009F0040 /* PushNotificationsNetworkable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushNotificationsNetworkable.swift; path = ../../Sources/PushNotificationsNetworkable.swift; sourceTree = "<group>"; };
 		A144AB471F9E3DA2009F0040 /* Device.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Device.swift; path = ../../Sources/Device.swift; sourceTree = "<group>"; };
 		A144AB481F9E3DA2009F0040 /* PushNotifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushNotifications.swift; path = ../../Sources/PushNotifications.swift; sourceTree = "<group>"; };
@@ -180,7 +178,6 @@
 				A1B344412018BC0100481BDF /* InterestValidationError.swift */,
 				A10552EC2028A934001E45D1 /* Metadata.swift */,
 				A1B344422018BC0200481BDF /* MultipleInvalidInterestsError.swift */,
-				A144AB451F9E3DA2009F0040 /* NetworkResponse.swift */,
 				A144AB4A1F9E3DA3009F0040 /* NetworkService.swift */,
 				A19ECF821FCF099100688DAF /* PersistenceService.swift */,
 				A10552EE2028C017001E45D1 /* PropertyListReadable.swift */,
@@ -369,7 +366,6 @@
 				A144AB511F9E3DA3009F0040 /* HTTPMethod.swift in Sources */,
 				A144AB501F9E3DA3009F0040 /* PushNotifications.swift in Sources */,
 				A1B344432018BC0200481BDF /* InterestValidationError.swift in Sources */,
-				A144AB4D1F9E3DA3009F0040 /* NetworkResponse.swift in Sources */,
 				A1504E17206B9D98002D1E74 /* EventTypeHandler.swift in Sources */,
 				A1B344442018BC0200481BDF /* MultipleInvalidInterestsError.swift in Sources */,
 				A1067109201F69B8001190F8 /* FeatureFlags.swift in Sources */,

--- a/Sources/NetworkResponse.swift
+++ b/Sources/NetworkResponse.swift
@@ -1,6 +1,0 @@
-import Foundation
-
-enum NetworkResponse {
-    case Success(data: Data)
-    case Failure(data: Data)
-}

--- a/Sources/NetworkService.swift
+++ b/Sources/NetworkService.swift
@@ -1,122 +1,116 @@
 import Foundation
 
-struct NetworkService: PushNotificationsNetworkable {
+class NetworkService: PushNotificationsNetworkable {
 
-    let url: URL
     let session: URLSession
+    let queue = DispatchQueue(label: "com.pusher.pushnotifications.sdk.network.queue")
+
+    init(session: URLSession) {
+        self.session = session
+    }
 
     // MARK: PushNotificationsNetworkable
-    func register(deviceToken: Data, instanceId: String, completion: @escaping CompletionHandler<Device>) {
+    func register(url: URL, deviceToken: Data, instanceId: String, completion: @escaping CompletionHandler<Device>) {
         let deviceTokenString = deviceToken.hexadecimalRepresentation()
         let bundleIdentifier = Bundle.main.bundleIdentifier ?? ""
 
         let metadata = Metadata.update()
 
         guard let body = try? Register(token: deviceTokenString, instanceId: instanceId, bundleIdentifier: bundleIdentifier, metadata: metadata).encode() else { return }
-        let request = self.setRequest(url: self.url, httpMethod: .POST, body: body)
+        let request = self.setRequest(url: url, httpMethod: .POST, body: body)
 
         self.networkRequest(request, session: self.session) { (response) in
-            switch response {
-            case .Success(let data):
-                guard let device = try? JSONDecoder().decode(Device.self, from: data) else { return }
-                completion(device, true)
-            case .Failure(let data):
-                guard let reason = try? JSONDecoder().decode(Reason.self, from: data) else { return }
-
-                print(reason.description)
-                completion(nil, false)
-            }
+            guard let device = try? JSONDecoder().decode(Device.self, from: response) else { return }
+            completion(device)
         }
     }
 
-    func subscribe(completion: @escaping CompletionHandler<String>) {
-        let request = self.setRequest(url: self.url, httpMethod: .POST)
+    func subscribe(url: URL, completion: @escaping CompletionHandler<String>) {
+        let request = self.setRequest(url: url, httpMethod: .POST)
 
-        self.networkRequest(request, session: self.session) { (response) in
-            switch response {
-            case .Success:
-                completion(nil, true)
-            case .Failure:
-                completion(nil, false)
-            }
+        self.networkRequest(request, session: self.session) { _ in
+            completion(nil)
         }
     }
 
-    func setSubscriptions(interests: [String], completion: @escaping CompletionHandler<String>) {
+    func setSubscriptions(url: URL, interests: [String], completion: @escaping CompletionHandler<String>) {
         guard let body = try? Interests(interests: interests).encode() else { return }
-        let request = self.setRequest(url: self.url, httpMethod: .PUT, body: body)
+        let request = self.setRequest(url: url, httpMethod: .PUT, body: body)
 
-        self.networkRequest(request, session: self.session) { (response) in
-            switch response {
-            case .Success:
-                completion(nil, true)
-            case .Failure:
-                completion(nil, false)
-            }
+        self.networkRequest(request, session: self.session) { _ in
+            completion(nil)
         }
     }
 
-    func unsubscribe(completion: @escaping CompletionHandler<String>) {
-        let request = self.setRequest(url: self.url, httpMethod: .DELETE)
+    func unsubscribe(url: URL, completion: @escaping CompletionHandler<String>) {
+        let request = self.setRequest(url: url, httpMethod: .DELETE)
 
-        self.networkRequest(request, session: self.session) { (response) in
-            switch response {
-            case .Success:
-                completion(nil, true)
-            case .Failure:
-                completion(nil, false)
-            }
+        self.networkRequest(request, session: self.session) { _ in
+            completion(nil)
         }
     }
 
-    func track(eventType: ReportEventType, completion: @escaping CompletionHandler<String>) {
+    func track(url: URL, eventType: ReportEventType, completion: @escaping CompletionHandler<String>) {
         guard let body = try? eventType.encode() else { return }
 
-        let request = self.setRequest(url: self.url, httpMethod: .POST, body: body)
-        self.networkRequest(request, session: self.session) { (response) in
-            switch response {
-            case .Success:
-                completion(nil, true)
-            case .Failure:
-                completion(nil, false)
-            }
+        let request = self.setRequest(url: url, httpMethod: .POST, body: body)
+        self.networkRequest(request, session: self.session) { _ in
+            completion(nil)
         }
     }
 
-    func syncMetadata(completion: @escaping CompletionHandler<String>) {
+    func syncMetadata(url: URL, completion: @escaping CompletionHandler<String>) {
         guard let metadataDictionary = Metadata.load() else { return }
         let metadata = Metadata(propertyListRepresentation: metadataDictionary)
         if metadata.hasChanged() {
             let updatedMetadataObject = Metadata.update()
             guard let body = try? updatedMetadataObject.encode() else { return }
-            let request = self.setRequest(url: self.url, httpMethod: .PUT, body: body)
-            self.networkRequest(request, session: self.session) { (response) in
-                switch response {
-                case .Success:
-                    completion(nil, true)
-                case .Failure:
-                    completion(nil, false)
-                }
+            let request = self.setRequest(url: url, httpMethod: .PUT, body: body)
+            self.networkRequest(request, session: self.session) { _ in
+                completion(nil)
             }
         }
     }
 
     // MARK: Networking Layer
-    private func networkRequest(_ request: URLRequest, session: URLSession, completion: @escaping (_ response: NetworkResponse) -> Void) {
-        session.dataTask(with: request, completionHandler: { (data, response, error) in
-            guard
-                let data = data,
-                let httpURLResponse = response as? HTTPURLResponse
-            else { return }
+    private func networkRequest(_ request: URLRequest, session: URLSession, completion: @escaping (_ response: Data) -> Void) {
+        self.queue.async {
+            self.queue.suspend()
 
-            let statusCode = httpURLResponse.statusCode
-            guard statusCode >= 200 && statusCode < 300, error == nil else {
-                return completion(NetworkResponse.Failure(data: data))
+            func networkRequestWithExponentialBackoff(numberOfAttempts: Int = 0) {
+                session.dataTask(with: request, completionHandler: { (data, response, error) in
+                    guard
+                        let data = data,
+                        let httpURLResponse = response as? HTTPURLResponse
+                    else {
+                        Thread.sleep(forTimeInterval: TimeInterval(self.calculateExponentialBackoffMs(attemptCount: numberOfAttempts) / 1000.0))
+                        return networkRequestWithExponentialBackoff(numberOfAttempts: numberOfAttempts + 1)
+                    }
+                    let statusCode = httpURLResponse.statusCode
+                    guard statusCode >= 200 && statusCode < 300, error == nil else {
+                        if let reason = try? JSONDecoder().decode(Reason.self, from: data) {
+                            print("[PushNotifications]: \(reason.description)")
+                        }
+
+                        Thread.sleep(forTimeInterval: TimeInterval(self.calculateExponentialBackoffMs(attemptCount: numberOfAttempts) / 1000.0))
+                        return networkRequestWithExponentialBackoff(numberOfAttempts: numberOfAttempts + 1)
+                    }
+
+                    self.queue.resume()
+
+                    completion(data)
+
+                }).resume()
             }
 
-            completion(NetworkResponse.Success(data: data))
+            networkRequestWithExponentialBackoff()
+        }
+    }
 
-        }).resume()
+    private let maxExponentialBackoffDelayMs = 32000.0
+    private let baseExponentialBackoffDelayMs = 200.0
+    private func calculateExponentialBackoffMs(attemptCount: Int) -> Double {
+        return min(maxExponentialBackoffDelayMs, baseExponentialBackoffDelayMs * pow(2.0, Double(attemptCount)))
     }
 
     private func setRequest(url: URL, httpMethod: HTTPMethod, body: Data? = nil) -> URLRequest {

--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -8,7 +8,7 @@ import NotificationCenter
 import Foundation
 
 @objc public final class PushNotifications: NSObject {
-    private let session = URLSession.shared
+    private let session = URLSession(configuration: .default)
     private let localStorageQueue = DispatchQueue(label: "com.pusher.pushnotifications.local.storage.queue")
     private let networkService: PushNotificationsNetworkable
 

--- a/Sources/PushNotificationsNetworkable.swift
+++ b/Sources/PushNotificationsNetworkable.swift
@@ -1,16 +1,16 @@
 import Foundation
 
-typealias CompletionHandler<T> = (_ result: T?, _ wasSuccessful: Bool) -> Void
+typealias CompletionHandler<T> = (_ result: T?) -> Void
 
 protocol PushNotificationsNetworkable {
-    func register(deviceToken: Data, instanceId: String, completion: @escaping CompletionHandler<Device>)
+    func register(url: URL, deviceToken: Data, instanceId: String, completion: @escaping CompletionHandler<Device>)
 
-    func subscribe(completion: @escaping CompletionHandler<String>)
-    func setSubscriptions(interests: [String], completion: @escaping CompletionHandler<String>)
+    func subscribe(url: URL, completion: @escaping CompletionHandler<String>)
+    func setSubscriptions(url: URL, interests: [String], completion: @escaping CompletionHandler<String>)
 
-    func unsubscribe(completion: @escaping CompletionHandler<String>)
+    func unsubscribe(url: URL, completion: @escaping CompletionHandler<String>)
 
-    func track(eventType: ReportEventType, completion: @escaping CompletionHandler<String>)
+    func track(url: URL, eventType: ReportEventType, completion: @escaping CompletionHandler<String>)
 
-    func syncMetadata(completion: @escaping CompletionHandler<String>)
+    func syncMetadata(url: URL, completion: @escaping CompletionHandler<String>)
 }


### PR DESCRIPTION
1. Remove NetworkResponse as it's not needed anymore. We don't return `Failure` instead we just retry the failed request with exponential backoff.
2. Changes to NetworkService:
	- Change to reference type.
	- Move the DispatchQueue inside the class. Queue takes care of orchestrating the network requests so they are executed in sequential order.
	- Initialisation of the NetworkService takes just session object.
	- Implement retry strategy with exponential backoff.
3. Change the PushNotificationsNetworkable protocol.
4. Update PushNotificationsNetworkable tests.
----
CC @pusher/mobile
