### PR TITLE
Sync interests when registering the device token if needed 

### DIFF
--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -128,12 +128,18 @@ import Foundation
                 } else {
                     Device.persist(device.id)
 
-                    if let initialInterestSet = device.initialInterestSet, initialInterestSet.count > 0 {
-                        let persistenceService: InterestPersistable = PersistenceService(service: UserDefaults(suiteName: "PushNotifications")!)
+                    let initialInterestSet = device.initialInterestSet ?? []
+                    let persistenceService: InterestPersistable = PersistenceService(service: UserDefaults(suiteName: "PushNotifications")!)
+                    if initialInterestSet.count > 0 {
                         persistenceService.persist(interests: initialInterestSet)
                     }
 
                     strongSelf.preIISOperationQueue.async {
+                        let interests = persistenceService.getSubscriptions() ?? []
+                        if !initialInterestSet.containsSameElements(as: interests) {
+                            strongSelf.syncInterests()
+                        }
+
                         completion()
                     }
 

--- a/push-notifications-ios/push-notifications-ios/AppDelegate.swift
+++ b/push-notifications-ios/push-notifications-ios/AppDelegate.swift
@@ -14,7 +14,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        self.pushNotifications.registerDeviceToken(deviceToken)
+        self.pushNotifications.registerDeviceToken(deviceToken) {
+            print("Ready to receive notifications!")
+        }
+
         try? self.pushNotifications.subscribe(interest: "hello")
     }
 

--- a/push-notifications-ios/push-notifications-ios/AppDelegate.swift
+++ b/push-notifications-ios/push-notifications-ios/AppDelegate.swift
@@ -14,11 +14,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        self.pushNotifications.registerDeviceToken(deviceToken) {
-            try? self.pushNotifications.subscribe(interest: "hello", completion: {
-                print("Ready to receive notifications!")
-            })
-        }
+        self.pushNotifications.registerDeviceToken(deviceToken)
+        try? self.pushNotifications.subscribe(interest: "hello")
     }
 
     func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {


### PR DESCRIPTION
### What?

* Sync any new interests persisted on the device when registering the device token with the Beams service.

* Update the code in the example project to show that it's not necessary anymore to call the handler upon completion.

----
CC @pusher/mobile