### PR TITLE
Add optional Error to completion block on registerDevice

### DIFF
--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -224,11 +224,13 @@ import Foundation
 
         if Device.idAlreadyPresent() {
             // TODO: Handle the token change.
+            completion(PushNotificationsError.error("Device is already present"))
             return
         }
 
         networkService.register(url: url, deviceToken: deviceToken, instanceId: instanceId) { [weak self] result in
             guard let strongSelf = self else {
+                completion(PushNotificationsError.error("deallocated"))
                 return
             }
 

--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -211,12 +211,12 @@ import Foundation
      - Precondition: `deviceToken` should not be nil.
      */
     /// - Tag: registerDeviceToken
-    @objc public func registerDeviceToken(_ deviceToken: Data, completion: @escaping () -> Void = {}) {
+    @objc public func registerDeviceToken(_ deviceToken: Data, completion: @escaping (Error?) -> Void = { _ in }) {
         guard
             let instanceId = Instance.getInstanceId(),
             let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")
         else {
-            print("[Push Notifications] - Something went wrong. Please check your instance id: \(String(describing: Instance.getInstanceId()))")
+            completion(PushNotificationsError.error("[Push Notifications] - Something went wrong. Please check your instance id: \(String(describing: Instance.getInstanceId()))"))
             return
         }
 
@@ -249,13 +249,13 @@ import Foundation
                             strongSelf.syncInterests()
                         }
 
-                        completion()
+                        completion(nil)
                     }
 
                     strongSelf.preIISOperationQueue.resume()
                 case .error(let error):
                     print("\(error)")
-                    completion()
+                    completion(error)
                 }
             }
         }


### PR DESCRIPTION
### What?

Added an optional `Error` to the completion block of `registerDevice` in `PushNotifications.swift`.

#### Why?

Whether the function succeeds or not (maybe the device is already registered), the completion function should still be called, but it should notify the user that there was an error and the intended `registerDevice` function wasn't completed.

My reason for doing this was I wanted to register a device then once registered (or if already registered) subscribe to an interest. Without this "fix" if the device was already registered, the completion function was never called.

----
CC @pusher/mobile
