### PR TITLE
Ignore the warning message when 'start' method is called from the 'enablePushNotifications' method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/push-notifications-swift/compare/2.0.0...HEAD)
+## [Unreleased](https://github.com/pusher/push-notifications-swift/compare/2.0.1...HEAD)
+
+## [2.0.1](https://github.com/pusher/push-notifications-swift/compare/2.0.0...2.0.1) - 2019-05-28
+
+## Added
+
+- Minor improvements.
 
 ## [2.0.0](https://github.com/pusher/push-notifications-swift/compare/1.3.0...2.0.0) - 2019-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Changed
 
-- Minor improvements.
+- Improve cases when a warning message is displayed.
 
 ## [2.0.0](https://github.com/pusher/push-notifications-swift/compare/1.3.0...2.0.0) - 2019-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.0.1](https://github.com/pusher/push-notifications-swift/compare/2.0.0...2.0.1) - 2019-05-28
 
-## Added
+## Changed
 
 - Minor improvements.
 

--- a/PushNotifications.podspec
+++ b/PushNotifications.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PushNotifications'
-  s.version          = '2.0.0'
+  s.version          = '2.0.1'
   s.summary          = 'PushNotifications SDK'
   s.homepage         = 'https://github.com/pusher/push-notifications-swift'
   s.license          = 'MIT'

--- a/PushNotifications/PushNotifications/Info.plist
+++ b/PushNotifications/PushNotifications/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>2.0.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/PushNotifications/PushNotificationsTests/Info.plist
+++ b/PushNotifications/PushNotificationsTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>2.0.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -71,7 +71,7 @@ import Foundation
 
         // Detect from where the function is being called
         let wasCalledFromCorrectLocation = Thread.callStackSymbols.contains { stack in
-            return stack.contains("didFinishLaunchingWith") || stack.contains("applicationDidFinishLaunching") || stack.contains("clearAllState")
+            return stack.contains("didFinishLaunchingWith") || stack.contains("applicationDidFinishLaunching") || stack.contains("clearAllState") || stack.contains("enablePushNotifications")
         }
         if !wasCalledFromCorrectLocation {
             print("[PushNotifications]: Warning: You should call `pushNotifications.start` from the `AppDelegate.didFinishLaunchingWith`")

--- a/Sources/SDK.swift
+++ b/Sources/SDK.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 struct SDK {
-    static let version = "2.0.0"
+    static let version = "2.0.1"
 }

--- a/Tests/SDKTests.swift
+++ b/Tests/SDKTests.swift
@@ -5,6 +5,6 @@ class SDKTests: XCTestCase {
     func testVersionModel() {
         let version = SDK.version
         XCTAssertNotNil(version)
-        XCTAssertEqual(version, "2.0.0")
+        XCTAssertEqual(version, "2.0.1")
     }
 }


### PR DESCRIPTION
### What?

Do not print the warning message when the `start` method is called from Chatkit.

#### Why?

Chatkit customers can enable push notifications whenever it makes the most sense in their application flow. This means that there will be cases where `enablePushNotifications` method will not be called in the `AppDelegate`.

----
CC @pusher/mobile
