### PR TITLE
Add support for macOS 10.10 and 10.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/push-notifications-swift/compare/2.0.1...HEAD)
+## [Unreleased](https://github.com/pusher/push-notifications-swift/compare/2.0.2...HEAD)
+
+## [2.0.2](https://github.com/pusher/push-notifications-swift/compare/2.0.1...2.0.2) - 2019-05-29
+
+## Added
+
+- Support for macOS versions:
+
+  - `10.10`
+  - `10.11`
 
 ## [2.0.1](https://github.com/pusher/push-notifications-swift/compare/2.0.0...2.0.1) - 2019-05-28
 

--- a/PushNotifications.podspec
+++ b/PushNotifications.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PushNotifications'
-  s.version          = '2.0.1'
+  s.version          = '2.0.2'
   s.summary          = 'PushNotifications SDK'
   s.homepage         = 'https://github.com/pusher/push-notifications-swift'
   s.license          = 'MIT'
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/**/*.swift'
 
   s.ios.deployment_target = '10.0'
-  s.osx.deployment_target = '10.12'
+  s.osx.deployment_target = '10.10'
 end

--- a/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
+++ b/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
@@ -719,7 +719,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pusher.PushNotifications;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = "";
@@ -746,7 +746,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pusher.PushNotifications;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = "";

--- a/PushNotifications/PushNotifications/Info.plist
+++ b/PushNotifications/PushNotifications/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.1</string>
+	<string>2.0.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/PushNotifications/PushNotificationsTests/Info.plist
+++ b/PushNotifications/PushNotificationsTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.1</string>
+	<string>2.0.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -150,9 +150,7 @@ import Foundation
             return
         }
 
-        let helpfulTimer = Timer.scheduledTimer(withTimeInterval: 15, repeats: false) { _ in
-            print("[PushNotifications] - It looks like setUserId hasn't completed yet -- have you called `registerDeviceToken`?")
-        }
+        let helpfulTimer = Timer.scheduledTimer(timeInterval: 15, target: self, selector: #selector(printHelpfulMessage), userInfo: nil, repeats: false)
 
         let wrapperCompletion: (Error?) -> Void = { error in
             helpfulTimer.invalidate()
@@ -165,6 +163,10 @@ import Foundation
             self.userIdCallbacks[userId] = [wrapperCompletion]
         }
         self.serverSyncHandler.sendMessage(serverSyncJob: ServerSyncJob.SetUserIdJob(userId: userId))
+    }
+
+    @objc private func printHelpfulMessage() {
+        print("[PushNotifications] - It looks like setUserId hasn't completed yet -- have you called `registerDeviceToken`?")
     }
 
     /**

--- a/Sources/SDK.swift
+++ b/Sources/SDK.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 struct SDK {
-    static let version = "2.0.1"
+    static let version = "2.0.2"
 }

--- a/Tests/SDKTests.swift
+++ b/Tests/SDKTests.swift
@@ -5,6 +5,6 @@ class SDKTests: XCTestCase {
     func testVersionModel() {
         let version = SDK.version
         XCTAssertNotNil(version)
-        XCTAssertEqual(version, "2.0.1")
+        XCTAssertEqual(version, "2.0.2")
     }
 }


### PR DESCRIPTION
### What?

Added back support for macOS `10.10` and `10.11` as it was before.

#### Why?

Fix for https://github.com/pusher/chatkit-swift/pull/181

----
CC @pusher/mobile
