### PR TITLE
Persist operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/push-notifications-swift/compare/2.0.2...HEAD)
+## [Unreleased](https://github.com/pusher/push-notifications-swift/compare/2.1.0...HEAD)
+
+## [2.1.0](https://github.com/pusher/push-notifications-swift/compare/2.0.2...2.1.0) - 2019-06-04
+
+## Added
+
+- Robuster synchronization logic.
 
 ## [2.0.2](https://github.com/pusher/push-notifications-swift/compare/2.0.1...2.0.2) - 2019-05-29
 

--- a/PushNotifications.podspec
+++ b/PushNotifications.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PushNotifications'
-  s.version          = '2.0.2'
+  s.version          = '2.1.0'
   s.summary          = 'PushNotifications SDK'
   s.homepage         = 'https://github.com/pusher/push-notifications-swift'
   s.license          = 'MIT'

--- a/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
+++ b/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		A108B1052237FE4D007FCB2D /* DeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A108B1012237FE4C007FCB2D /* DeviceTests.swift */; };
 		A108B1062237FE4D007FCB2D /* InterestPersistableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A108B1022237FE4C007FCB2D /* InterestPersistableTests.swift */; };
 		A108B1072237FE4D007FCB2D /* UserPersistableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A108B1032237FE4C007FCB2D /* UserPersistableTests.swift */; };
+		A126312322CA705600DDAD28 /* ServerSyncJobStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A126312222CA705600DDAD28 /* ServerSyncJobStore.swift */; };
+		A126312722CB726900DDAD28 /* ServerSyncJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = A126312622CB726900DDAD28 /* ServerSyncJob.swift */; };
 		A1327BDF2178EB62001483E1 /* BeamsTokenProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1327BDC2178EB61001483E1 /* BeamsTokenProvider.swift */; };
 		A1327BE02178EB62001483E1 /* AuthData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1327BDD2178EB62001483E1 /* AuthData.swift */; };
 		A1327BE12178EB62001483E1 /* TokenProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1327BDE2178EB62001483E1 /* TokenProvider.swift */; };
@@ -119,6 +121,8 @@
 		A108B1022237FE4C007FCB2D /* InterestPersistableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterestPersistableTests.swift; sourceTree = "<group>"; };
 		A108B1032237FE4C007FCB2D /* UserPersistableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserPersistableTests.swift; sourceTree = "<group>"; };
 		A1197BD6206266D200FD7335 /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = ../Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
+		A126312222CA705600DDAD28 /* ServerSyncJobStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSyncJobStore.swift; sourceTree = "<group>"; };
+		A126312622CB726900DDAD28 /* ServerSyncJob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ServerSyncJob.swift; path = ../ServerSyncJob.swift; sourceTree = "<group>"; };
 		A1327BDC2178EB61001483E1 /* BeamsTokenProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BeamsTokenProvider.swift; path = ../../Sources/BeamsTokenProvider.swift; sourceTree = "<group>"; };
 		A1327BDD2178EB62001483E1 /* AuthData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuthData.swift; path = ../../Sources/AuthData.swift; sourceTree = "<group>"; };
 		A1327BDE2178EB62001483E1 /* TokenProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TokenProvider.swift; path = ../../Sources/TokenProvider.swift; sourceTree = "<group>"; };
@@ -201,6 +205,8 @@
 				A19ECF811FCF099100688DAF /* InterestPersistable.swift */,
 				A1482A532180A47900F19A4E /* UserPersistable.swift */,
 				A10552EC2028A934001E45D1 /* Metadata.swift */,
+				A126312222CA705600DDAD28 /* ServerSyncJobStore.swift */,
+				A126312622CB726900DDAD28 /* ServerSyncJob.swift */,
 			);
 			name = Persistence;
 			path = ../../Sources/Persistence;
@@ -506,6 +512,7 @@
 				A1327BDF2178EB62001483E1 /* BeamsTokenProvider.swift in Sources */,
 				A1F0E942219B18B800D32363 /* PushNotificationsError.swift in Sources */,
 				A1327BE02178EB62001483E1 /* AuthData.swift in Sources */,
+				A126312722CB726900DDAD28 /* ServerSyncJob.swift in Sources */,
 				A19ECF831FCF099200688DAF /* InterestPersistable.swift in Sources */,
 				A1482A582181F3CD00F19A4E /* Result.swift in Sources */,
 				A1D2AC3D22560D3E00AF4871 /* String+HexStringToData.swift in Sources */,
@@ -535,6 +542,7 @@
 				A108811B20334D860091E8EB /* Instance.swift in Sources */,
 				A16782551FA0EA2D00A193DF /* Reason.swift in Sources */,
 				A108B0CF2237FBF8007FCB2D /* DeviceStateStore.swift in Sources */,
+				A126312322CA705600DDAD28 /* ServerSyncJobStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PushNotifications/PushNotifications/Info.plist
+++ b/PushNotifications/PushNotifications/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.2</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/PushNotifications/PushNotificationsTests/Info.plist
+++ b/PushNotifications/PushNotificationsTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.2</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/Sources/API/NetworkService.swift
+++ b/Sources/API/NetworkService.swift
@@ -211,8 +211,7 @@ class NetworkService: PushNotificationsNetworkable {
                 // Hack, until we add error codes in the server.
                 if reason?.description.contains("device token") ?? false {
                     result = .error(PushNotificationsAPIError.BadDeviceToken(reason: reason!.description))
-                }
-                else {
+                } else {
                     result = .error(PushNotificationsAPIError.BadJWT(reason: reason?.description  ?? "Unknown API error"))
                 }
             case 404:

--- a/Sources/Internal/ServerSyncProcessHandler.swift
+++ b/Sources/Internal/ServerSyncProcessHandler.swift
@@ -242,7 +242,7 @@ class ServerSyncProcessHandler {
                             semaphore.signal()
                         })
                         semaphore.wait()
-                    } catch(let error) {
+                    } catch (let error) {
                         print("[PushNotifications]: Warning - Unexpected error: \(error.localizedDescription)")
                         DeviceStateStore.usersService.removeUserId()
                     }

--- a/Sources/Internal/ServerSyncProcessHandler.swift
+++ b/Sources/Internal/ServerSyncProcessHandler.swift
@@ -2,7 +2,7 @@ import Foundation
 
 class ServerSyncProcessHandler {
     private let sendMessageQueue: DispatchQueue
-    private let queue: DispatchQueue
+    private let handleMessageQueue: DispatchQueue
     private let networkService: NetworkService
     private let getTokenProvider: () -> TokenProvider?
     private let handleServerSyncEvent: (ServerSyncEvent) -> Void
@@ -12,7 +12,7 @@ class ServerSyncProcessHandler {
         self.getTokenProvider = getTokenProvider
         self.handleServerSyncEvent = handleServerSyncEvent
         self.sendMessageQueue = DispatchQueue(label: "sendMessageQueue")
-        self.queue = DispatchQueue(label: "queue")
+        self.handleMessageQueue = DispatchQueue(label: "handleMessageQueue")
         let session = URLSession(configuration: .ephemeral)
         self.networkService = NetworkService(session: session)
 
@@ -23,7 +23,7 @@ class ServerSyncProcessHandler {
                 // there should be another setUserIdJob being enqueued upon launch
                 return
             default:
-                self.queue.async {
+                self.handleMessageQueue.async {
                     self.handleMessage(serverSyncJob: job)
                 }
             }
@@ -34,7 +34,7 @@ class ServerSyncProcessHandler {
         self.sendMessageQueue.async {
             self.jobQueue.append(serverSyncJob)
 
-            self.queue.async {
+            self.handleMessageQueue.async {
                 self.handleMessage(serverSyncJob: serverSyncJob)
             }
         }

--- a/Sources/Internal/ServerSyncProcessHandler.swift
+++ b/Sources/Internal/ServerSyncProcessHandler.swift
@@ -19,9 +19,9 @@ class ServerSyncProcessHandler {
         self.jobQueue.toList().forEach { job in
             switch job {
             case .SetUserIdJob:
-                return
-                // skipping it. If the user is still supposed to logged in, then
+                // Skipping it. If the user is still supposed to logged in, then
                 // there should be another setUserIdJob being enqueued upon launch
+                return
             default:
                 self.queue.async {
                     self.handleMessage(serverSyncJob: job)

--- a/Sources/Internal/ServerSyncProcessHandler.swift
+++ b/Sources/Internal/ServerSyncProcessHandler.swift
@@ -242,8 +242,7 @@ class ServerSyncProcessHandler {
                             semaphore.signal()
                         })
                         semaphore.wait()
-                    }
-                    catch(let error) {
+                    } catch(let error) {
                         print("[PushNotifications]: Warning - Unexpected error: \(error.localizedDescription)")
                         DeviceStateStore.usersService.removeUserId()
                     }
@@ -287,8 +286,7 @@ class ServerSyncProcessHandler {
                 semaphore.signal()
             })
             semaphore.wait()
-        }
-        catch (let error) {
+        } catch (let error) {
             let error = TokenProviderError.error("[PushNotifications] - Error when executing `fetchToken` method: \(error)")
             self.handleServerSyncEvent(.UserIdSetEvent(userId: userId, error: error))
         }

--- a/Sources/Persistence/DeviceStateStore.swift
+++ b/Sources/Persistence/DeviceStateStore.swift
@@ -7,7 +7,7 @@ public class DeviceStateStore {
     static let pushNotificationsInstance: PushNotificationsInstancePersistable = PersistenceService(service: UserDefaults(suiteName: Constants.UserDefaults.suiteName)!)
 
     public static func synchronize<T>(f: () -> T) -> T {
-        var result: T? = nil
+        var result: T?
         DeviceStateStore.queue.sync {
             result = f()
         }

--- a/Sources/Persistence/Metadata.swift
+++ b/Sources/Persistence/Metadata.swift
@@ -10,7 +10,7 @@ public struct Metadata: Equatable, Codable {
     static func getCurrentMetadata() -> Metadata {
         let sdkVersion = SDK.version
         let systemVersion = SystemVersion.version
-        
+
         #if os(iOS)
         return Metadata(sdkVersion: sdkVersion, iosVersion: systemVersion, macosVersion: nil)
         #elseif os(OSX)

--- a/Sources/Persistence/ServerSyncJobStore.swift
+++ b/Sources/Persistence/ServerSyncJobStore.swift
@@ -3,14 +3,14 @@ import Foundation
 struct ServerSyncJobStore {
 
     private var jobStoreArray: [ServerSyncJob] = []
-    private let syncJobStoreQueue = DispatchQueue(label: "store")
+    private let syncJobStoreQueue = DispatchQueue(label: "syncJobStoreQueue")
 
     init() {
         self.jobStoreArray = self.loadOperations()
     }
 
     private func loadOperations() -> [ServerSyncJob] {
-        guard let operations = NSData(contentsOfFile: "store") else {
+        guard let operations = NSData(contentsOfFile: "syncJobStoreQueue") else {
             return []
         }
 
@@ -50,7 +50,7 @@ struct ServerSyncJobStore {
 
             let jsonEncoder = JSONEncoder()
             let data = try! jsonEncoder.encode(jobStoreArray)
-            try! (data as NSData).write(toFile: "store", options: .atomic)
+            try! (data as NSData).write(toFile: "syncJobStoreQueue", options: .atomic)
         }
     }
 
@@ -61,7 +61,7 @@ struct ServerSyncJobStore {
 
                 let jsonEncoder = JSONEncoder()
                 let data = try! jsonEncoder.encode(jobStoreArray)
-                try! (data as NSData).write(toFile: "store", options: .atomic)
+                try! (data as NSData).write(toFile: "syncJobStoreQueue", options: .atomic)
             }
         }
     }

--- a/Sources/Persistence/ServerSyncJobStore.swift
+++ b/Sources/Persistence/ServerSyncJobStore.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct ServerSyncJobStore {
-    private let syncJobStore = "syncJobStore"
+    private let syncJobStoreFileName = "syncJobStore"
     private var jobStoreArray: [ServerSyncJob] = []
     private let syncJobStoreQueue = DispatchQueue(label: "syncJobStoreQueue")
 
@@ -10,8 +10,8 @@ struct ServerSyncJobStore {
     }
 
     private func loadOperations() -> [ServerSyncJob] {
-        guard let operations = NSData(contentsOfFile: syncJobStore) else {
-            print("[PushNotifications] - Failed to load previously stored operations, continuing without them.")
+        guard let operations = NSData(contentsOfFile: syncJobStoreFileName) else {
+            // Assuming a fresh installation here
             return []
         }
 
@@ -27,14 +27,13 @@ struct ServerSyncJobStore {
     private func persistOperations(_ jobStoreArray: [ServerSyncJob]) {
         let jsonEncoder = JSONEncoder()
         guard let data = try? jsonEncoder.encode(jobStoreArray) else {
-            print("[PushNotifications] - Failed to encode operations, continuing without them.")
+            print("[PushNotifications] - Failed to encode operations, continuing without persisting them.")
             return
         }
         do {
-            try (data as NSData).write(toFile: syncJobStore, options: .atomic)
-        }
-        catch {
-            print("[PushNotifications] - Failed to persist operations, continuing without them.")
+            try (data as NSData).write(toFile: syncJobStoreFileName, options: .atomic)
+        } catch {
+            print("[PushNotifications] - Failed to persist operations, continuing ...")
         }
     }
 

--- a/Sources/Persistence/ServerSyncJobStore.swift
+++ b/Sources/Persistence/ServerSyncJobStore.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct ServerSyncJobStore {
-
+    private let syncJobStore = "syncJobStore"
     private var jobStoreArray: [ServerSyncJob] = []
     private let syncJobStoreQueue = DispatchQueue(label: "syncJobStoreQueue")
 
@@ -10,7 +10,7 @@ struct ServerSyncJobStore {
     }
 
     private func loadOperations() -> [ServerSyncJob] {
-        guard let operations = NSData(contentsOfFile: "syncJobStoreQueue") else {
+        guard let operations = NSData(contentsOfFile: syncJobStore) else {
             print("[PushNotifications] - Failed to load previously stored operations, continuing without them.")
             return []
         }
@@ -52,7 +52,7 @@ struct ServerSyncJobStore {
 
             let jsonEncoder = JSONEncoder()
             let data = try! jsonEncoder.encode(jobStoreArray)
-            try! (data as NSData).write(toFile: "syncJobStoreQueue", options: .atomic)
+            try! (data as NSData).write(toFile: syncJobStore, options: .atomic)
         }
     }
 
@@ -63,7 +63,7 @@ struct ServerSyncJobStore {
 
                 let jsonEncoder = JSONEncoder()
                 let data = try! jsonEncoder.encode(jobStoreArray)
-                try! (data as NSData).write(toFile: "syncJobStoreQueue", options: .atomic)
+                try! (data as NSData).write(toFile: syncJobStore, options: .atomic)
             }
         }
     }

--- a/Sources/Persistence/ServerSyncJobStore.swift
+++ b/Sources/Persistence/ServerSyncJobStore.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+struct ServerSyncJobStore {
+
+    private var jobStoreArray: [ServerSyncJob]
+
+    init() {
+        self.jobStoreArray = []
+
+        self.jobStoreArray = self.loadOperations()
+    }
+
+    func loadOperations() -> [ServerSyncJob] {
+        guard let operations = NSData(contentsOfFile: "store") else {
+            return []
+        }
+
+        let jsonDecoder = JSONDecoder()
+        guard let operationsArray = try? jsonDecoder.decode([ServerSyncJob].self, from: (operations as Data)) else {
+            return []
+        }
+
+        return operationsArray
+    }
+
+    var isEmpty: Bool {
+        get {
+            return self.jobStoreArray.isEmpty
+        }
+    }
+
+    var first: ServerSyncJob? {
+        get {
+            return jobStoreArray.first
+        }
+    }
+
+    func toList() -> [ServerSyncJob] {
+        return self.jobStoreArray
+    }
+    
+    mutating func append(_ job: ServerSyncJob) {
+        var operations = self.loadOperations()
+        operations.append(job)
+        if(self.jobStoreArray.count > 0) {
+            self.jobStoreArray.removeAll()
+        }
+
+        let jsonEncoder = JSONEncoder()
+        guard let data = try? jsonEncoder.encode(operations) else {
+            return
+        }
+
+        try! (data as NSData).write(toFile: "store", options: .atomic)
+
+        self.jobStoreArray = operations
+    }
+
+    mutating func removeFirst() {
+        if(self.jobStoreArray.count > 0) {
+            self.jobStoreArray.removeFirst()
+
+            let jsonEncoder = JSONEncoder()
+            guard let data = try? jsonEncoder.encode(jobStoreArray) else {
+                return
+            }
+            try! (data as NSData).write(toFile: "store", options: .atomic)
+        }
+    }
+}

--- a/Sources/Persistence/ServerSyncJobStore.swift
+++ b/Sources/Persistence/ServerSyncJobStore.swift
@@ -11,11 +11,13 @@ struct ServerSyncJobStore {
 
     private func loadOperations() -> [ServerSyncJob] {
         guard let operations = NSData(contentsOfFile: "syncJobStoreQueue") else {
+            print("[PushNotifications] - Failed to load previously stored operations, continuing without them.")
             return []
         }
 
         let jsonDecoder = JSONDecoder()
         guard let operationsArray = try? jsonDecoder.decode([ServerSyncJob].self, from: (operations as Data)) else {
+            print("[PushNotifications] - Failed to load previously stored operations, continuing without them.")
             return []
         }
 

--- a/Sources/Persistence/ServerSyncJobStore.swift
+++ b/Sources/Persistence/ServerSyncJobStore.swift
@@ -43,7 +43,7 @@ struct ServerSyncJobStore {
             return self.jobStoreArray
         }
     }
-    
+
     mutating func append(_ job: ServerSyncJob) {
         syncJobStoreQueue.sync {
             self.jobStoreArray.append(job)

--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -133,7 +133,7 @@ import Foundation
 
         PushNotifications.shared.tokenProvider = tokenProvider
 
-        var localUserIdDifferent: Bool? = nil
+        var localUserIdDifferent: Bool?
         DeviceStateStore.synchronize {
             if let userIdExists = DeviceStateStore.pushNotificationsInstance.getUserIdPreviouslyCalledWith() {
                 localUserIdDifferent = userIdExists != userId

--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -24,12 +24,16 @@ import Foundation
                 case .InterestsChangedEvent(let interests):
                     self?.delegate?.interestsSetOnDeviceDidChange(interests: interests)
                 case .UserIdSetEvent(let userId, let error):
-                    if let completion = self?.userIdCallbacks[userId]?.removeFirst() {
-                        completion(error)
+                    if !(self?.userIdCallbacks.isEmpty ?? true) {
+                        if let completion = self?.userIdCallbacks[userId]?.removeFirst() {
+                            completion(error)
+                        }
                     }
                 case .StopEvent:
-                    if let completion = self?.stopCallbacks.removeFirst() {
-                        completion()
+                    if !(self?.stopCallbacks.isEmpty ?? true) {
+                        if let completion = self?.stopCallbacks.removeFirst() {
+                            completion()
+                        }
                     }
                 }
             }

--- a/Sources/PushNotificationsInstancePersistable.swift
+++ b/Sources/PushNotificationsInstancePersistable.swift
@@ -9,5 +9,3 @@ protocol PushNotificationsInstancePersistable {
 
     func clear()
 }
-
-

--- a/Sources/ReportEventType.swift
+++ b/Sources/ReportEventType.swift
@@ -2,7 +2,7 @@ import Foundation
 
 protocol ReportEventType: Encodable {}
 
-struct OpenEventType: ReportEventType {
+struct OpenEventType: ReportEventType, Codable {
     let event: String
     let publishId: String
     let deviceId: String
@@ -18,7 +18,7 @@ struct OpenEventType: ReportEventType {
     }
 }
 
-struct DeliveryEventType: ReportEventType {
+struct DeliveryEventType: ReportEventType, Codable {
     let event: String
     let publishId: String
     let deviceId: String

--- a/Sources/SDK.swift
+++ b/Sources/SDK.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 struct SDK {
-    static let version = "2.0.2"
+    static let version = "2.1.0"
 }

--- a/Sources/ServerSyncJob.swift
+++ b/Sources/ServerSyncJob.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-
-
 enum ServerSyncJob {
     case StartJob(instanceId: String, token: String)
     case RefreshTokenJob(newToken: String)
@@ -40,7 +38,6 @@ extension ServerSyncJob: Codable {
         case openEventTypeKey
         case deliveryEventTypeKey
     }
-
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/ServerSyncJob.swift
+++ b/Sources/ServerSyncJob.swift
@@ -93,7 +93,6 @@ extension ServerSyncJob: Codable {
             self = .StopJob
             return
         }
-
     }
 
     func encode(to encoder: Encoder) throws {
@@ -146,6 +145,5 @@ extension ServerSyncJob: Codable {
             let v: Discriminator = .StopJobKey
             try container.encode(v, forKey: k)
         }
-
     }
 }

--- a/Sources/ServerSyncJob.swift
+++ b/Sources/ServerSyncJob.swift
@@ -15,14 +15,14 @@ enum ServerSyncJob {
 extension ServerSyncJob: Codable {
     enum Discriminator: Int, Codable {
         case StartJobKey = 0
-        case RefreshTokenJobKey
-        case SubscribeJobKey
-        case UnsubscribeJobKey
-        case SetSubscriptionsKey
-        case ApplicationStartJobKey
-        case SetUserIdJobKey
-        case ReportEventJobKey
-        case StopJobKey
+        case RefreshTokenJobKey = 1
+        case SubscribeJobKey = 2
+        case UnsubscribeJobKey = 3
+        case SetSubscriptionsKey = 4
+        case ApplicationStartJobKey = 5
+        case SetUserIdJobKey = 6
+        case ReportEventJobKey = 7
+        case StopJobKey = 8
     }
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/ServerSyncJob.swift
+++ b/Sources/ServerSyncJob.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+
+
+enum ServerSyncJob {
+    case StartJob(instanceId: String, token: String)
+    case RefreshTokenJob(newToken: String)
+    case SubscribeJob(interest: String, localInterestsChanged: Bool)
+    case UnsubscribeJob(interest: String, localInterestsChanged: Bool)
+    case SetSubscriptions(interests: [String], localInterestsChanged: Bool)
+    case ApplicationStartJob(metadata: Metadata)
+    case SetUserIdJob(userId: String)
+    case ReportEventJob(eventType: ReportEventType)
+    case StopJob
+}
+
+extension ServerSyncJob: Codable {
+    enum Discriminator: Int, Codable {
+        case StartJobKey = 0
+        case RefreshTokenJobKey
+        case SubscribeJobKey
+        case UnsubscribeJobKey
+        case SetSubscriptionsKey
+        case ApplicationStartJobKey
+        case SetUserIdJobKey
+        case ReportEventJobKey
+        case StopJobKey
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case discriminator
+        case startJobInstanceIdKey
+        case startJobTokenKey
+        case newTokenKey
+        case interestKey
+        case localInterestsChangedKey
+        case interestsKey
+        case metadataKey
+        case userIdKey
+        case openEventTypeKey
+        case deliveryEventTypeKey
+    }
+
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let discriminator = try container.decode(Discriminator.self, forKey: .discriminator)
+        switch discriminator {
+        case .StartJobKey:
+            let instanceId = try container.decode(String.self, forKey: .startJobInstanceIdKey)
+            let token = try container.decode(String.self, forKey: .startJobTokenKey)
+            self = .StartJob(instanceId: instanceId, token: token)
+            return
+        case .RefreshTokenJobKey:
+            let newToken = try container.decode(String.self, forKey: .newTokenKey)
+            self = .RefreshTokenJob(newToken: newToken)
+            return
+        case .SubscribeJobKey:
+            let interest = try container.decode(String.self, forKey: .interestKey)
+            let localInterestsChangedKey = try container.decode(Bool.self, forKey: .localInterestsChangedKey)
+            self = .SubscribeJob(interest: interest, localInterestsChanged: localInterestsChangedKey)
+            return
+        case .UnsubscribeJobKey:
+            let interest = try container.decode(String.self, forKey: .interestKey)
+            let localInterestsChangedKey = try container.decode(Bool.self, forKey: .localInterestsChangedKey)
+            self = .UnsubscribeJob(interest: interest, localInterestsChanged: localInterestsChangedKey)
+            return
+        case .SetSubscriptionsKey:
+            let interests = try container.decode([String].self, forKey: .interestsKey)
+            let localInterestsChangedKey = try container.decode(Bool.self, forKey: .localInterestsChangedKey)
+            self = .SetSubscriptions(interests: interests, localInterestsChanged: localInterestsChangedKey)
+            return
+        case .ApplicationStartJobKey:
+            let metadata = try container.decode(Metadata.self, forKey: .metadataKey)
+            self = .ApplicationStartJob(metadata: metadata)
+            return
+        case .SetUserIdJobKey:
+            let userId = try container.decode(String.self, forKey: .userIdKey)
+            self = .SetUserIdJob(userId: userId)
+            return
+        case .ReportEventJobKey:
+            if let openEventType = try? container.decode(OpenEventType.self, forKey: .openEventTypeKey) {
+                self = .ReportEventJob(eventType: openEventType)
+                return
+            }
+            if let deliveryEventType = try? container.decode(DeliveryEventType.self, forKey: .deliveryEventTypeKey) {
+                self = .ReportEventJob(eventType: deliveryEventType)
+                return
+            }
+            self = .ReportEventJob(eventType: OpenEventType.init(publishId: "", deviceId: "", userId: "", timestampSecs: 0))
+        case .StopJobKey:
+            self = .StopJob
+            return
+        }
+
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        let k: CodingKeys = .discriminator
+
+        switch self {
+        case .StartJob(let instanceId, let token):
+            let v: Discriminator = .StartJobKey
+            try container.encode(v, forKey: k)
+            try container.encode(instanceId, forKey: .startJobInstanceIdKey)
+            try container.encode(token, forKey: .startJobTokenKey)
+        case .RefreshTokenJob(let newToken):
+            let v: Discriminator = .RefreshTokenJobKey
+            try container.encode(v, forKey: k)
+            try container.encode(newToken, forKey: .newTokenKey)
+        case .SubscribeJob(let interest, let localInterestsChanged):
+            let v: Discriminator = .SubscribeJobKey
+            try container.encode(v, forKey: k)
+            try container.encode(interest, forKey: .interestKey)
+            try container.encode(localInterestsChanged, forKey: .localInterestsChangedKey)
+        case .UnsubscribeJob(let interest, let localInterestsChanged):
+            let v: Discriminator = .UnsubscribeJobKey
+            try container.encode(v, forKey: k)
+            try container.encode(interest, forKey: .interestKey)
+            try container.encode(localInterestsChanged, forKey: .localInterestsChangedKey)
+        case .SetSubscriptions(let interests, let localInterestsChanged):
+            let v: Discriminator = .SetSubscriptionsKey
+            try container.encode(v, forKey: k)
+            try container.encode(interests, forKey: .interestsKey)
+            try container.encode(localInterestsChanged, forKey: .localInterestsChangedKey)
+        case .ApplicationStartJob(let metadata):
+            let v: Discriminator = .ApplicationStartJobKey
+            try container.encode(v, forKey: k)
+            try container.encode(metadata, forKey: .metadataKey)
+        case .SetUserIdJob(let userId):
+            let v: Discriminator = .SetUserIdJobKey
+            try container.encode(v, forKey: k)
+            try container.encode(userId, forKey: .userIdKey)
+        case .ReportEventJob(let eventType):
+            let v: Discriminator = .ReportEventJobKey
+            try container.encode(v, forKey: k)
+            if let openEventType = eventType as? OpenEventType {
+                try container.encode(openEventType, forKey: .openEventTypeKey)
+            }
+            if let deliveryEventType = eventType as? DeliveryEventType {
+                try container.encode(deliveryEventType, forKey: .deliveryEventTypeKey)
+            }
+        case .StopJob:
+            let v: Discriminator = .StopJobKey
+            try container.encode(v, forKey: k)
+        }
+
+    }
+}

--- a/Tests/IntegrationTests/ApplicationStartTests.swift
+++ b/Tests/IntegrationTests/ApplicationStartTests.swift
@@ -15,6 +15,8 @@ class ApplicationStartTests: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
+
+        try? FileManager.default.removeItem(atPath: "store")
     }
 
     override func tearDown() {
@@ -25,6 +27,8 @@ class ApplicationStartTests: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
+
+        try? FileManager.default.removeItem(atPath: "store")
     }
 
     func testApplicationStartWillSyncInterests() {

--- a/Tests/IntegrationTests/ApplicationStartTests.swift
+++ b/Tests/IntegrationTests/ApplicationStartTests.swift
@@ -16,7 +16,7 @@ class ApplicationStartTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "store")
+        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
     }
 
     override func tearDown() {
@@ -28,7 +28,7 @@ class ApplicationStartTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "store")
+        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
     }
 
     func testApplicationStartWillSyncInterests() {

--- a/Tests/IntegrationTests/ClearAllStateTest.swift
+++ b/Tests/IntegrationTests/ClearAllStateTest.swift
@@ -15,6 +15,8 @@ class ClearAllStateTest: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
+
+        try? FileManager.default.removeItem(atPath: "store")
     }
 
     override func tearDown() {
@@ -25,6 +27,8 @@ class ClearAllStateTest: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
+
+        try? FileManager.default.removeItem(atPath: "store")
     }
 
     func testItShouldClearAllState() {

--- a/Tests/IntegrationTests/ClearAllStateTest.swift
+++ b/Tests/IntegrationTests/ClearAllStateTest.swift
@@ -16,7 +16,7 @@ class ClearAllStateTest: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "store")
+        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
     }
 
     override func tearDown() {
@@ -28,7 +28,7 @@ class ClearAllStateTest: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "store")
+        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
     }
 
     func testItShouldClearAllState() {

--- a/Tests/IntegrationTests/DeviceInterestsTest.swift
+++ b/Tests/IntegrationTests/DeviceInterestsTest.swift
@@ -15,6 +15,8 @@ class DeviceInterestsTest: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
+
+        try? FileManager.default.removeItem(atPath: "store")
     }
 
     override func tearDown() {
@@ -25,6 +27,8 @@ class DeviceInterestsTest: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
+
+        try? FileManager.default.removeItem(atPath: "store")
     }
 
     func testInterestNameValidation() {

--- a/Tests/IntegrationTests/DeviceInterestsTest.swift
+++ b/Tests/IntegrationTests/DeviceInterestsTest.swift
@@ -16,7 +16,7 @@ class DeviceInterestsTest: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "store")
+        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
     }
 
     override func tearDown() {
@@ -28,7 +28,7 @@ class DeviceInterestsTest: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "store")
+        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
     }
 
     func testInterestNameValidation() {

--- a/Tests/IntegrationTests/DeviceRegistrationTests.swift
+++ b/Tests/IntegrationTests/DeviceRegistrationTests.swift
@@ -16,7 +16,7 @@ class DeviceRegistrationTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "store")
+        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
     }
 
     override func tearDown() {
@@ -28,7 +28,7 @@ class DeviceRegistrationTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "store")
+        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
     }
 
     func testStartRegisterDeviceTokenResultsInDeviceIdBeingStored() {

--- a/Tests/IntegrationTests/DeviceRegistrationTests.swift
+++ b/Tests/IntegrationTests/DeviceRegistrationTests.swift
@@ -15,6 +15,8 @@ class DeviceRegistrationTests: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
+
+        try? FileManager.default.removeItem(atPath: "store")
     }
 
     override func tearDown() {
@@ -25,6 +27,8 @@ class DeviceRegistrationTests: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
+
+        try? FileManager.default.removeItem(atPath: "store")
     }
 
     func testStartRegisterDeviceTokenResultsInDeviceIdBeingStored() {

--- a/Tests/IntegrationTests/ReportEventTypeTests.swift
+++ b/Tests/IntegrationTests/ReportEventTypeTests.swift
@@ -16,7 +16,7 @@ class ReportEventTypeTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "store")
+        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
     }
 
     override func tearDown() {
@@ -28,7 +28,7 @@ class ReportEventTypeTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "store")
+        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
     }
 
     func testHandleNotification() {

--- a/Tests/IntegrationTests/ReportEventTypeTests.swift
+++ b/Tests/IntegrationTests/ReportEventTypeTests.swift
@@ -15,6 +15,8 @@ class ReportEventTypeTests: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
+
+        try? FileManager.default.removeItem(atPath: "store")
     }
 
     override func tearDown() {
@@ -25,6 +27,8 @@ class ReportEventTypeTests: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
+
+        try? FileManager.default.removeItem(atPath: "store")
     }
 
     func testHandleNotification() {

--- a/Tests/IntegrationTests/SetUserIdTest.swift
+++ b/Tests/IntegrationTests/SetUserIdTest.swift
@@ -17,7 +17,7 @@ class SetUserIdTest: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "store")
+        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
     }
 
     override func tearDown() {
@@ -29,7 +29,7 @@ class SetUserIdTest: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "store")
+        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
     }
 
     func testSetUserIdShouldAssociateThisDeviceWithUserOnTheServer() {

--- a/Tests/IntegrationTests/SetUserIdTest.swift
+++ b/Tests/IntegrationTests/SetUserIdTest.swift
@@ -16,6 +16,8 @@ class SetUserIdTest: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
+
+        try? FileManager.default.removeItem(atPath: "store")
     }
 
     override func tearDown() {
@@ -26,6 +28,8 @@ class SetUserIdTest: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
+
+        try? FileManager.default.removeItem(atPath: "store")
     }
 
     func testSetUserIdShouldAssociateThisDeviceWithUserOnTheServer() {

--- a/Tests/IntegrationTests/StopTests.swift
+++ b/Tests/IntegrationTests/StopTests.swift
@@ -15,6 +15,8 @@ class StopTests: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
+
+        try? FileManager.default.removeItem(atPath: "store")
     }
 
     override func tearDown() {
@@ -25,6 +27,8 @@ class StopTests: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
+
+        try? FileManager.default.removeItem(atPath: "store")
     }
 
     func testStopShouldDeleteDeviceOnTheServer() {

--- a/Tests/IntegrationTests/StopTests.swift
+++ b/Tests/IntegrationTests/StopTests.swift
@@ -16,7 +16,7 @@ class StopTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "store")
+        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
     }
 
     override func tearDown() {
@@ -28,7 +28,7 @@ class StopTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "store")
+        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
     }
 
     func testStopShouldDeleteDeviceOnTheServer() {

--- a/Tests/SDKTests.swift
+++ b/Tests/SDKTests.swift
@@ -5,6 +5,6 @@ class SDKTests: XCTestCase {
     func testVersionModel() {
         let version = SDK.version
         XCTAssertNotNil(version)
-        XCTAssertEqual(version, "2.0.2")
+        XCTAssertEqual(version, "2.1.0")
     }
 }

--- a/push-notifications-ios/push-notifications-ios/Info.plist
+++ b/push-notifications-ios/push-notifications-ios/Info.plist
@@ -2,11 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/push-notifications-ios/push-notifications-ios/Info.plist
+++ b/push-notifications-ios/push-notifications-ios/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
### What?

Persist all operations to the disk.

#### Why?

Previously, operations were stored in the memory. If many operations would be enqueued and device would crash, SDK would lost track of the ones that were not yet synchronised with the server.
With this change, operations will be stored to disk and persisted so we can resume syncing when app restarts.

----
CC @pusher/mobile
