### PR TITLE
Remove the sync job store in all tests

### DIFF
--- a/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
+++ b/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		A1F122E42237C90600F7D766 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F122E22237C90500F7D766 /* NetworkService.swift */; };
 		A1F122E62237C94600F7D766 /* RetryStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F122E52237C94600F7D766 /* RetryStrategy.swift */; };
 		A1F122E82237C9D400F7D766 /* PushNotificationsAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F122E72237C9D400F7D766 /* PushNotificationsAPIError.swift */; };
+		D33A751623858D64002E64CB /* TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33A751523858D64002E64CB /* TestHelper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -174,6 +175,7 @@
 		A1F122E22237C90500F7D766 /* NetworkService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		A1F122E52237C94600F7D766 /* RetryStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryStrategy.swift; sourceTree = "<group>"; };
 		A1F122E72237C9D400F7D766 /* PushNotificationsAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationsAPIError.swift; sourceTree = "<group>"; };
+		D33A751523858D64002E64CB /* TestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -339,6 +341,7 @@
 				A1D2AC3E225653A600AF4871 /* SetUserIdTest.swift */,
 				A1424C1D225E061200BCE570 /* ReportEventTypeTests.swift */,
 				A1424C21225E20EA00BCE570 /* ApplicationStartTests.swift */,
+				D33A751523858D64002E64CB /* TestHelper.swift */,
 			);
 			name = IntegrationTests;
 			path = ../../Tests/IntegrationTests;
@@ -573,6 +576,7 @@
 				A108B0F82237FD51007FCB2D /* InterestsMD5HashTests.swift in Sources */,
 				A108B0F12237FD51007FCB2D /* RegisterTests.swift in Sources */,
 				A1D2AC3F225653A600AF4871 /* SetUserIdTest.swift in Sources */,
+				D33A751623858D64002E64CB /* TestHelper.swift in Sources */,
 				A1C41F7B2253B4BC00497D87 /* DeviceRegistrationTests.swift in Sources */,
 				A108B0ED2237FD51007FCB2D /* ReasonTests.swift in Sources */,
 				A108B1072237FE4D007FCB2D /* UserPersistableTests.swift in Sources */,

--- a/Tests/IntegrationTests/ApplicationStartTests.swift
+++ b/Tests/IntegrationTests/ApplicationStartTests.swift
@@ -15,7 +15,6 @@ class ApplicationStartTests: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
-        
         TestHelper().removeSyncjobStore()
     }
 
@@ -27,7 +26,6 @@ class ApplicationStartTests: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
-        
         TestHelper().removeSyncjobStore()
     }
 

--- a/Tests/IntegrationTests/ApplicationStartTests.swift
+++ b/Tests/IntegrationTests/ApplicationStartTests.swift
@@ -15,8 +15,8 @@ class ApplicationStartTests: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
-
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        
+        TestHelper().removeSyncjobStore()
     }
 
     override func tearDown() {
@@ -27,8 +27,8 @@ class ApplicationStartTests: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
-
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        
+        TestHelper().removeSyncjobStore()
     }
 
     func testApplicationStartWillSyncInterests() {

--- a/Tests/IntegrationTests/ClearAllStateTest.swift
+++ b/Tests/IntegrationTests/ClearAllStateTest.swift
@@ -16,7 +16,7 @@ class ClearAllStateTest: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     override func tearDown() {
@@ -28,7 +28,7 @@ class ClearAllStateTest: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     func testItShouldClearAllState() {

--- a/Tests/IntegrationTests/DeviceInterestsTest.swift
+++ b/Tests/IntegrationTests/DeviceInterestsTest.swift
@@ -16,7 +16,7 @@ class DeviceInterestsTest: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     override func tearDown() {
@@ -28,7 +28,7 @@ class DeviceInterestsTest: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     func testInterestNameValidation() {

--- a/Tests/IntegrationTests/DeviceRegistrationTests.swift
+++ b/Tests/IntegrationTests/DeviceRegistrationTests.swift
@@ -16,7 +16,7 @@ class DeviceRegistrationTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     override func tearDown() {
@@ -28,7 +28,7 @@ class DeviceRegistrationTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     func testStartRegisterDeviceTokenResultsInDeviceIdBeingStored() {

--- a/Tests/IntegrationTests/ReportEventTypeTests.swift
+++ b/Tests/IntegrationTests/ReportEventTypeTests.swift
@@ -16,7 +16,7 @@ class ReportEventTypeTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     override func tearDown() {
@@ -28,7 +28,7 @@ class ReportEventTypeTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     func testHandleNotification() {

--- a/Tests/IntegrationTests/SetUserIdTest.swift
+++ b/Tests/IntegrationTests/SetUserIdTest.swift
@@ -17,7 +17,7 @@ class SetUserIdTest: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+       TestHelper().removeSyncjobStore()
     }
 
     override func tearDown() {
@@ -29,7 +29,7 @@ class SetUserIdTest: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     func testSetUserIdShouldAssociateThisDeviceWithUserOnTheServer() {

--- a/Tests/IntegrationTests/StopTests.swift
+++ b/Tests/IntegrationTests/StopTests.swift
@@ -16,7 +16,7 @@ class StopTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     override func tearDown() {
@@ -28,7 +28,7 @@ class StopTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     func testStopShouldDeleteDeviceOnTheServer() {

--- a/Tests/IntegrationTests/TestHelper.swift
+++ b/Tests/IntegrationTests/TestHelper.swift
@@ -1,0 +1,19 @@
+//
+//  TestHelper.swift
+//  PushNotificationsTests
+//
+//  Created by Danielle Vass on 20/11/2019.
+//  Copyright © 2019 Pusher. All rights reserved.
+//
+
+import Foundation
+
+struct TestHelper {
+
+    func removeSyncjobStore() {
+        let url = try! FileManager.default.url(for: .libraryDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+        let filePath = url.appendingPathComponent("syncJobStore")
+        try? FileManager.default.removeItem(atPath:  filePath.relativePath)
+    }
+    
+}


### PR DESCRIPTION
### What?
Added a utility method to remove the sync job store correctly using the file path, and used it everywhere we were removing the wrong file.
...

#### Why?
We had test interference where if we ran `device interests tests` then `application start tests` the interests would still persist and would cause other tests to file. This wasn't noticed earlier because when all the tests are run in order the `stop tests` also cleans everything properly.
