### PR TITLE
Multi instance refactor api

### DIFF
--- a/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
+++ b/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		A1F122E42237C90600F7D766 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F122E22237C90500F7D766 /* NetworkService.swift */; };
 		A1F122E62237C94600F7D766 /* RetryStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F122E52237C94600F7D766 /* RetryStrategy.swift */; };
 		A1F122E82237C9D400F7D766 /* PushNotificationsAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F122E72237C9D400F7D766 /* PushNotificationsAPIError.swift */; };
+		D33A751623858D64002E64CB /* TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33A751523858D64002E64CB /* TestHelper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -174,6 +175,7 @@
 		A1F122E22237C90500F7D766 /* NetworkService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		A1F122E52237C94600F7D766 /* RetryStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryStrategy.swift; sourceTree = "<group>"; };
 		A1F122E72237C9D400F7D766 /* PushNotificationsAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationsAPIError.swift; sourceTree = "<group>"; };
+		D33A751523858D64002E64CB /* TestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -339,6 +341,7 @@
 				A1D2AC3E225653A600AF4871 /* SetUserIdTest.swift */,
 				A1424C1D225E061200BCE570 /* ReportEventTypeTests.swift */,
 				A1424C21225E20EA00BCE570 /* ApplicationStartTests.swift */,
+				D33A751523858D64002E64CB /* TestHelper.swift */,
 			);
 			name = IntegrationTests;
 			path = ../../Tests/IntegrationTests;
@@ -573,6 +576,7 @@
 				A108B0F82237FD51007FCB2D /* InterestsMD5HashTests.swift in Sources */,
 				A108B0F12237FD51007FCB2D /* RegisterTests.swift in Sources */,
 				A1D2AC3F225653A600AF4871 /* SetUserIdTest.swift in Sources */,
+				D33A751623858D64002E64CB /* TestHelper.swift in Sources */,
 				A1C41F7B2253B4BC00497D87 /* DeviceRegistrationTests.swift in Sources */,
 				A108B0ED2237FD51007FCB2D /* ReasonTests.swift in Sources */,
 				A108B1072237FE4D007FCB2D /* UserPersistableTests.swift in Sources */,

--- a/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
+++ b/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
@@ -81,7 +81,8 @@
 		A1F122E42237C90600F7D766 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F122E22237C90500F7D766 /* NetworkService.swift */; };
 		A1F122E62237C94600F7D766 /* RetryStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F122E52237C94600F7D766 /* RetryStrategy.swift */; };
 		A1F122E82237C9D400F7D766 /* PushNotificationsAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F122E72237C9D400F7D766 /* PushNotificationsAPIError.swift */; };
-		D33A751623858D64002E64CB /* TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33A751523858D64002E64CB /* TestHelper.swift */; };
+		D323BB812385992800A618F4 /* TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D323BB802385992800A618F4 /* TestHelper.swift */; };
+		D3FBCEA5238555C400CD9B8F /* PushNotificationsStatic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FBCEA4238555C400CD9B8F /* PushNotificationsStatic.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -175,7 +176,8 @@
 		A1F122E22237C90500F7D766 /* NetworkService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		A1F122E52237C94600F7D766 /* RetryStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryStrategy.swift; sourceTree = "<group>"; };
 		A1F122E72237C9D400F7D766 /* PushNotificationsAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationsAPIError.swift; sourceTree = "<group>"; };
-		D33A751523858D64002E64CB /* TestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelper.swift; sourceTree = "<group>"; };
+		D323BB802385992800A618F4 /* TestHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelper.swift; sourceTree = "<group>"; };
+		D3FBCEA4238555C400CD9B8F /* PushNotificationsStatic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationsStatic.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -288,6 +290,7 @@
 				A1E80013201A3DAC00467EB9 /* PublishId.swift */,
 				A108811820334D860091E8EB /* PusherAlreadyRegisteredError.swift */,
 				A155BFB61F9E38040070A609 /* PushNotifications.h */,
+				D3FBCEA4238555C400CD9B8F /* PushNotificationsStatic.swift */,
 				A144AB481F9E3DA2009F0040 /* PushNotifications.swift */,
 				A1F0E941219B18B800D32363 /* PushNotificationsError.swift */,
 				A16782541FA0EA2C00A193DF /* Reason.swift */,
@@ -341,7 +344,7 @@
 				A1D2AC3E225653A600AF4871 /* SetUserIdTest.swift */,
 				A1424C1D225E061200BCE570 /* ReportEventTypeTests.swift */,
 				A1424C21225E20EA00BCE570 /* ApplicationStartTests.swift */,
-				D33A751523858D64002E64CB /* TestHelper.swift */,
+				D323BB802385992800A618F4 /* TestHelper.swift */,
 			);
 			name = IntegrationTests;
 			path = ../../Tests/IntegrationTests;
@@ -505,6 +508,7 @@
 				A1F122E32237C90600F7D766 /* PushNotificationsNetworkable.swift in Sources */,
 				A1F122E82237C9D400F7D766 /* PushNotificationsAPIError.swift in Sources */,
 				A140FFD72020C5E600931AF6 /* SDK.swift in Sources */,
+				D3FBCEA5238555C400CD9B8F /* PushNotificationsStatic.swift in Sources */,
 				A144AB4C1F9E3DA3009F0040 /* DeviceTokenHelper.swift in Sources */,
 				A140FFD12020BE5700931AF6 /* Encodable+Encode.swift in Sources */,
 				A1D2AC4122565FE400AF4871 /* PushNotificationsInstancePersistable.swift in Sources */,
@@ -576,7 +580,7 @@
 				A108B0F82237FD51007FCB2D /* InterestsMD5HashTests.swift in Sources */,
 				A108B0F12237FD51007FCB2D /* RegisterTests.swift in Sources */,
 				A1D2AC3F225653A600AF4871 /* SetUserIdTest.swift in Sources */,
-				D33A751623858D64002E64CB /* TestHelper.swift in Sources */,
+				D323BB812385992800A618F4 /* TestHelper.swift in Sources */,
 				A1C41F7B2253B4BC00497D87 /* DeviceRegistrationTests.swift in Sources */,
 				A108B0ED2237FD51007FCB2D /* ReasonTests.swift in Sources */,
 				A108B1072237FE4D007FCB2D /* UserPersistableTests.swift in Sources */,

--- a/PushNotifications/PushNotifications/PushNotificationsStatic.swift
+++ b/PushNotifications/PushNotifications/PushNotificationsStatic.swift
@@ -1,0 +1,241 @@
+#if os(iOS)
+import UIKit
+import UserNotifications
+#elseif os(OSX)
+import Cocoa
+import NotificationCenter
+#endif
+import Foundation
+
+@objc public final class PushNotificationStatic: NSObject {
+    
+    private override init() {
+        // prevent other people initialising us
+    }
+    
+    private static var instance: PushNotifications?
+    internal static var tokenProvider: TokenProvider?
+    
+    /**
+     Start PushNotifications service.
+
+     - Parameter instanceId: PushNotifications instance id.
+
+     - Precondition: `instanceId` should not be nil.
+     */
+    /// - Tag: start
+    @objc public static func start(instanceId: String) {
+        if (instance == nil) {
+            instance = PushNotifications(instanceId: instanceId)
+        }
+        instance?.start(instanceId: instanceId)
+        //todo: handle starting different instances
+        
+    }
+    
+    /**
+     Register to receive remote notifications via Apple Push Notification service.
+
+     Convenience method is using `.alert`, `.sound`, and `.badge` as default authorization options.
+
+     - SeeAlso:  `registerForRemoteNotifications(options:)`
+     */
+    /// - Tag: register
+    @objc public static func registerForRemoteNotifications() {
+        if let staticInstance = instance {
+            staticInstance.registerForRemoteNotifications()
+        } else {
+            fatalError("PushNotifications.shared.start must have been called first")
+        }
+    }
+    
+    #if os(iOS)
+    /**
+     Register to receive remote notifications via Apple Push Notification service.
+     
+     - Parameter options: The authorization options your app is requesting. You may combine the available constants to request authorization for multiple items. Request only the authorization options that you plan to use. For a list of possible values, see [UNAuthorizationOptions](https://developer.apple.com/documentation/usernotifications/unauthorizationoptions).
+     */
+    /// - Tag: registerOptions
+    @objc public static func registerForRemoteNotifications(options: UNAuthorizationOptions) {
+        if let staticInstance = instance {
+            staticInstance.registerForRemoteNotifications(options: options)
+        } else {
+            fatalError("PushNotifications.shared.start must have been called first")
+        }
+    }
+    #elseif os(OSX)
+    /**
+     Register to receive remote notifications via Apple Push Notification service.
+     
+     - Parameter options: A bit mask specifying the types of notifications the app accepts. See [NSApplication.RemoteNotificationType](https://developer.apple.com/documentation/appkit/nsapplication.remotenotificationtype) for valid bit-mask values.
+     */
+    @objc public static func registerForRemoteNotifications(options: NSApplication.RemoteNotificationType) {
+        if let staticInstance = instance {
+            staticInstance.registerForRemoteNotifications(options: options)
+        } else {
+            fatalError("PushNotifications.shared.start must have been called first")
+        }
+    }
+    #endif
+    
+    /**
+     Set user id.
+     
+     - Parameter userId: User id.
+     - Parameter tokenProvider: Token provider that will be used to generate the token for the user that you want to authenticate.
+     - Parameter completion: The block to execute after attempt to set user id has been made.
+     */
+    /// - Tag: setUserId
+    @objc public static func setUserId(_ userId: String, tokenProvider: TokenProvider, completion: @escaping (Error?) -> Void) {
+        if let staticInstance = instance {
+            staticInstance.setUserId(userId, tokenProvider: tokenProvider, completion: completion)
+        } else {
+            fatalError("PushNotifications.shared.start must have been called first")
+        }
+    }
+    
+    /**
+     Disable Beams service.
+     
+     This will remove everything associated with the Beams from the device and Beams server.
+     - Parameter completion: The block to execute after the device has been deleted from the server.
+     */
+    /// - Tag: stop
+    @objc public static func stop(completion: @escaping () -> Void) {
+        if let staticInstance = instance {
+            staticInstance.stop(completion: completion)
+        } else {
+            fatalError("PushNotifications.shared.start must have been called first")
+        }
+    }
+    
+    /**
+     Clears all the state on the SDK leaving it in the empty started state.
+     
+     This will remove the current user and all the interests associated with it from the device and Beams server.
+     Device is now in a fresh state, ready for new subscriptions or user being set.
+     - Parameter completion: The block to execute after the device has been deleted from the server.
+     */
+    /// - Tag: clearAllState
+    @objc public static func clearAllState(completion: @escaping () -> Void) {
+        if let staticInstance = instance {
+            staticInstance.clearAllState(completion: completion)
+        } else {
+            fatalError("PushNotifications.shared.start must have been called first")
+        }
+    }
+    
+    /**
+     Register device token with PushNotifications service.
+     
+     - Parameter deviceToken: A token that identifies the device to APNs.
+     
+     - Precondition: `deviceToken` should not be nil.
+     */
+    /// - Tag: registerDeviceToken
+    @objc public static func registerDeviceToken(_ deviceToken: Data) {
+        if let staticInstance = instance {
+            staticInstance.registerDeviceToken(deviceToken)
+        } else {
+            fatalError("PushNotifications.shared.start must have been called first")
+        }
+    }
+    
+    /**
+     Subscribes the device to an interest.
+     
+     - Parameter interest: Interest that you want to subscribe your device to.
+     
+     - Precondition: `interest` should not be nil.
+     
+     - Throws: An error of type `InvalidInterestError`
+     */
+    /// - Tag: addDeviceInterest
+    @objc public static func addDeviceInterest(interest: String) throws {
+        if let staticInstance = instance {
+            try staticInstance.addDeviceInterest(interest: interest)
+        } else {
+            fatalError("PushNotifications.shared.start must have been called first")
+        }
+    }
+    
+    /**
+     Sets the subscriptions state for the device.
+     Any interests not in the set will be unsubscribed from, so this will replace the interest set by the one provided.
+     
+     - Parameter interests: Interests that you want to subscribe your device to.
+     
+     - Precondition: `interests` should not be nil.
+     
+     - Throws: An error of type `MultipleInvalidInterestsError`
+     */
+    /// - Tag: setDeviceInterests
+    @objc public static func setDeviceInterests(interests: [String]) throws {
+        if let staticInstance = instance {
+            try staticInstance.setDeviceInterests(interests: interests)
+        } else {
+            fatalError("PushNotifications.shared.start must have been called first")
+        }
+    }
+    
+    /**
+     Unsubscribe the device from an interest.
+     
+     - Parameter interest: Interest that you want to unsubscribe your device from.
+     
+     - Precondition: `interest` should not be nil.
+     
+     - Throws: An error of type `InvalidInterestError`
+     */
+    /// - Tag: removeDeviceInterest
+    @objc public static func removeDeviceInterest(interest: String) throws {
+        if let staticInstance = instance {
+            try staticInstance.removeDeviceInterest(interest: interest)
+        } else {
+            fatalError("PushNotifications.shared.start must have been called first")
+        }
+    }
+    
+    ///Unsubscribes the device from all the interests.
+    /// - Tag: clearDeviceInterests
+    @objc public static func clearDeviceInterests() throws {
+        if let staticInstance = instance {
+            try staticInstance.clearDeviceInterests()
+        } else {
+            fatalError("PushNotifications.shared.start must have been called first")
+        }
+    }
+    
+    /**
+     Get the interest subscriptions that the device is currently subscribed to.
+     
+     - returns: Array of interests
+     */
+    /// - Tag: getDeviceInterests
+    @objc public static func getDeviceInterests() -> [String]? {
+        if let staticInstance = instance {
+            return staticInstance.getDeviceInterests()
+        } else {
+            fatalError("PushNotifications.shared.start must have been called first")
+        }
+        return nil
+    }
+    
+    /**
+     Handle Remote Notification.
+     
+     - Parameter userInfo: Remote Notification payload.
+     */
+    /// - Tag: handleNotification
+    @discardableResult
+    @objc public static func handleNotification(userInfo: [AnyHashable: Any]) -> RemoteNotificationType {
+        if let staticInstance = instance {
+            return staticInstance.handleNotification(userInfo: userInfo)
+        } else {
+            fatalError("PushNotifications.shared.start must have been called first")
+        }
+        return RemoteNotificationType.ShouldProcess
+    }
+    
+    
+}

--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -8,11 +8,16 @@ import NotificationCenter
 import Foundation
 
 @objc public final class PushNotifications: NSObject {
+    
+    private var instanceId: String
+    
+    init(instanceId: String) {
+        self.instanceId = instanceId
+    }
+    
     //! Returns a shared singleton PushNotifications object.
     /// - Tag: shared
-    @objc public static let shared = PushNotifications()
-
-    private var tokenProvider: TokenProvider?
+    @objc public static let shared = PushNotificationStatic.self
 
     private var userIdCallbacks = Dictionary<String, [(Error?) -> Void]>()
     private var stopCallbacks = [() -> Void]()

--- a/Tests/IntegrationTests/ApplicationStartTests.swift
+++ b/Tests/IntegrationTests/ApplicationStartTests.swift
@@ -30,7 +30,7 @@ class ApplicationStartTests: XCTestCase {
     }
 
     func testApplicationStartWillSyncInterests() {
-        let pushNotifications = PushNotifications.shared
+        let pushNotifications = PushNotifications(instanceId: instanceId)
         pushNotifications.start(instanceId: instanceId)
 
         pushNotifications.registerDeviceToken(validToken)

--- a/Tests/IntegrationTests/ApplicationStartTests.swift
+++ b/Tests/IntegrationTests/ApplicationStartTests.swift
@@ -15,7 +15,6 @@ class ApplicationStartTests: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
-        
         TestHelper().removeSyncjobStore()
     }
 
@@ -27,7 +26,6 @@ class ApplicationStartTests: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
-        
         TestHelper().removeSyncjobStore()
     }
 

--- a/Tests/IntegrationTests/ApplicationStartTests.swift
+++ b/Tests/IntegrationTests/ApplicationStartTests.swift
@@ -15,8 +15,8 @@ class ApplicationStartTests: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
-
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        
+        TestHelper().removeSyncjobStore()
     }
 
     override func tearDown() {
@@ -27,8 +27,8 @@ class ApplicationStartTests: XCTestCase {
         UserDefaults(suiteName: Constants.UserDefaults.suiteName).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
-
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        
+        TestHelper().removeSyncjobStore()
     }
 
     func testApplicationStartWillSyncInterests() {

--- a/Tests/IntegrationTests/ClearAllStateTest.swift
+++ b/Tests/IntegrationTests/ClearAllStateTest.swift
@@ -32,7 +32,7 @@ class ClearAllStateTest: XCTestCase {
     }
 
     func testItShouldClearAllState() {
-        let pushNotifications = PushNotifications()
+        let pushNotifications = PushNotifications(instanceId: instanceId)
         pushNotifications.start(instanceId: instanceId)
         pushNotifications.registerDeviceToken(validToken)
 

--- a/Tests/IntegrationTests/ClearAllStateTest.swift
+++ b/Tests/IntegrationTests/ClearAllStateTest.swift
@@ -16,7 +16,7 @@ class ClearAllStateTest: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     override func tearDown() {
@@ -28,7 +28,7 @@ class ClearAllStateTest: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     func testItShouldClearAllState() {

--- a/Tests/IntegrationTests/DeviceInterestsTest.swift
+++ b/Tests/IntegrationTests/DeviceInterestsTest.swift
@@ -32,14 +32,14 @@ class DeviceInterestsTest: XCTestCase {
     }
 
     func testInterestNameValidation() {
-        let pushNotifications = PushNotifications.shared
+        let pushNotifications = PushNotifications(instanceId: instanceId)
         XCTAssertThrowsError(try pushNotifications.addDeviceInterest(interest: "hello$*"))
         XCTAssertThrowsError(try pushNotifications.removeDeviceInterest(interest: "hello$*"))
 
         let invalidInterests = ["¢123", "#ssss#dds", "£", "hello|world"]
         let validInterests = ["a;b", "hello-world", "pusher.com", "@cucas", "apples,grapes,oranges==fruit"]
         let allInterests = invalidInterests + validInterests
-        XCTAssertThrowsError(try PushNotifications.shared.setDeviceInterests(interests: allInterests)) { error in
+        XCTAssertThrowsError(try pushNotifications.setDeviceInterests(interests: allInterests)) { error in
             guard case MultipleInvalidInterestsError.invalidNames(let names) = error else {
                 return XCTFail()
             }
@@ -60,7 +60,7 @@ class DeviceInterestsTest: XCTestCase {
     }
 
     func testSubscribingAndUnsubscribingBeforeTheStartWorks() {
-        let pushNotifications = PushNotifications.shared
+        let pushNotifications = PushNotifications(instanceId: instanceId)
         XCTAssertNoThrow(try pushNotifications.addDeviceInterest(interest: "panda"))
         var interests = pushNotifications.getDeviceInterests()
         XCTAssertNotNil(interests)
@@ -76,7 +76,7 @@ class DeviceInterestsTest: XCTestCase {
     }
 
     func testInterestsShouldBeSynchronisedAfterStart() {
-        let pushNotifications = PushNotifications.shared
+        let pushNotifications = PushNotifications(instanceId: instanceId)
         XCTAssertNoThrow(try pushNotifications.addDeviceInterest(interest: "panda"))
 
         pushNotifications.start(instanceId: instanceId)
@@ -91,7 +91,7 @@ class DeviceInterestsTest: XCTestCase {
 
     func testLocalInterestsSetShouldBeMergedAfterDeviceRegistration() {
         // Creating device and setting interests to simulate preexisting device with interests.
-        let pushNotifications = PushNotifications()
+        let pushNotifications = PushNotifications(instanceId: instanceId)
         XCTAssertNoThrow(try pushNotifications.addDeviceInterest(interest: "panda"))
         XCTAssertNoThrow(try pushNotifications.addDeviceInterest(interest: "zebra"))
 
@@ -110,7 +110,7 @@ class DeviceInterestsTest: XCTestCase {
         }
 
         // Creating new instance to pretend a fresh state
-        let pushNotifications2 = PushNotifications()
+        let pushNotifications2 = PushNotifications(instanceId: instanceId)
         XCTAssertNoThrow(try pushNotifications2.removeDeviceInterest(interest: "panda"))
         XCTAssertNoThrow(try pushNotifications2.addDeviceInterest(interest: "lion"))
 
@@ -144,7 +144,7 @@ class DeviceInterestsTest: XCTestCase {
     }
 
     func testInterestsSetDidChangeAndCallbackIsCalled() {
-        let pushNotifications = PushNotifications()
+        let pushNotifications = PushNotifications(instanceId: instanceId)
 
         class StubInterestsChanged: InterestsChangedDelegate {
             let completion: ([String]) -> ()
@@ -215,4 +215,5 @@ class DeviceInterestsTest: XCTestCase {
 
         waitForExpectations(timeout: 1)
     }
+
 }

--- a/Tests/IntegrationTests/DeviceInterestsTest.swift
+++ b/Tests/IntegrationTests/DeviceInterestsTest.swift
@@ -16,7 +16,7 @@ class DeviceInterestsTest: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     override func tearDown() {
@@ -28,7 +28,7 @@ class DeviceInterestsTest: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     func testInterestNameValidation() {

--- a/Tests/IntegrationTests/DeviceRegistrationTests.swift
+++ b/Tests/IntegrationTests/DeviceRegistrationTests.swift
@@ -16,7 +16,7 @@ class DeviceRegistrationTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     override func tearDown() {
@@ -28,7 +28,7 @@ class DeviceRegistrationTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     func testStartRegisterDeviceTokenResultsInDeviceIdBeingStored() {

--- a/Tests/IntegrationTests/ReportEventTypeTests.swift
+++ b/Tests/IntegrationTests/ReportEventTypeTests.swift
@@ -16,7 +16,7 @@ class ReportEventTypeTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     override func tearDown() {
@@ -28,7 +28,7 @@ class ReportEventTypeTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     func testHandleNotification() {

--- a/Tests/IntegrationTests/SetUserIdTest.swift
+++ b/Tests/IntegrationTests/SetUserIdTest.swift
@@ -33,7 +33,7 @@ class SetUserIdTest: XCTestCase {
     }
 
     func testSetUserIdShouldAssociateThisDeviceWithUserOnTheServer() {
-        let pushNotifications = PushNotifications()
+        let pushNotifications = PushNotifications(instanceId: instanceId)
         pushNotifications.start(instanceId: instanceId)
         pushNotifications.registerDeviceToken(validToken)
 
@@ -48,7 +48,7 @@ class SetUserIdTest: XCTestCase {
     }
 
     func testSetUserIdShouldThrowExceptionIfUserIdIsReassigned() {
-        let pushNotifications = PushNotifications()
+        let pushNotifications = PushNotifications(instanceId: instanceId)
         pushNotifications.start(instanceId: instanceId)
         pushNotifications.registerDeviceToken(validToken)
         let expCucas = expectation(description: "Set user id for cucas should succeed")
@@ -69,7 +69,7 @@ class SetUserIdTest: XCTestCase {
     }
 
     func testSetUserIdCallStopAndSettingADifferentUserIdSucceeds() {
-        let pushNotifications = PushNotifications()
+        let pushNotifications = PushNotifications(instanceId: instanceId)
         pushNotifications.start(instanceId: instanceId)
         pushNotifications.registerDeviceToken(validToken)
 
@@ -90,7 +90,7 @@ class SetUserIdTest: XCTestCase {
     }
 
     func testSetUserIdShouldReturnErrorIfStartHasNotBeenCalled() {
-        let pushNotifications = PushNotifications()
+        let pushNotifications = PushNotifications(instanceId: instanceId)
         let exp = expectation(description: "It should return an error")
         let tokenProvider = StubTokenProvider(jwt: validCucasJWTToken, error: nil)
         pushNotifications.setUserId("cucas", tokenProvider: tokenProvider) { error in

--- a/Tests/IntegrationTests/SetUserIdTest.swift
+++ b/Tests/IntegrationTests/SetUserIdTest.swift
@@ -17,7 +17,7 @@ class SetUserIdTest: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+       TestHelper().removeSyncjobStore()
     }
 
     override func tearDown() {
@@ -29,7 +29,7 @@ class SetUserIdTest: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     func testSetUserIdShouldAssociateThisDeviceWithUserOnTheServer() {

--- a/Tests/IntegrationTests/StopTests.swift
+++ b/Tests/IntegrationTests/StopTests.swift
@@ -32,7 +32,7 @@ class StopTests: XCTestCase {
     }
 
     func testStopShouldDeleteDeviceOnTheServer() {
-        let pushNotifications = PushNotifications()
+        let pushNotifications = PushNotifications(instanceId: instanceId)
         pushNotifications.start(instanceId: instanceId)
         pushNotifications.registerDeviceToken(validToken)
 
@@ -51,7 +51,7 @@ class StopTests: XCTestCase {
     }
 
     func testShouldDeleteLocalInterests() {
-        let pushNotifications = PushNotifications()
+        let pushNotifications = PushNotifications(instanceId: instanceId)
         pushNotifications.start(instanceId: instanceId)
         pushNotifications.registerDeviceToken(validToken)
 
@@ -63,7 +63,7 @@ class StopTests: XCTestCase {
     }
 
     func testAfterStopStartingAgainShouldBePossible() {
-        let pushNotifications = PushNotifications()
+        let pushNotifications = PushNotifications(instanceId: instanceId)
         pushNotifications.start(instanceId: instanceId)
         pushNotifications.registerDeviceToken(validToken)
 

--- a/Tests/IntegrationTests/StopTests.swift
+++ b/Tests/IntegrationTests/StopTests.swift
@@ -16,7 +16,7 @@ class StopTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     override func tearDown() {
@@ -28,7 +28,7 @@ class StopTests: XCTestCase {
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
 
-        try? FileManager.default.removeItem(atPath: "syncJobStoreQueue")
+        TestHelper().removeSyncjobStore()
     }
 
     func testStopShouldDeleteDeviceOnTheServer() {

--- a/Tests/IntegrationTests/TestHelper.swift
+++ b/Tests/IntegrationTests/TestHelper.swift
@@ -1,0 +1,19 @@
+//
+//  TestHelper.swift
+//  PushNotificationsTests
+//
+//  Created by Danielle Vass on 20/11/2019.
+//  Copyright © 2019 Pusher. All rights reserved.
+//
+
+import Foundation
+
+struct TestHelper {
+
+    func removeSyncjobStore() {
+        let url = try! FileManager.default.url(for: .libraryDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+        let filePath = url.appendingPathComponent("syncJobStore")
+        try? FileManager.default.removeItem(atPath:  filePath.relativePath)
+    }
+    
+}


### PR DESCRIPTION
### What?
Refactor the API to begin supporting multiple instances in the SDK
...

#### Why?
This makes the SDK more similar to the android way of handling multiple instances in the same app
...

----
CC @pusher/mobile
