### PR TITLE
Multi instance refactor start

### DIFF
--- a/PushNotifications/PushNotifications/PushNotificationsStatic.swift
+++ b/PushNotifications/PushNotifications/PushNotificationsStatic.swift
@@ -28,7 +28,7 @@ import Foundation
         if (instance == nil) {
             instance = PushNotifications(instanceId: instanceId)
         }
-        instance?.start(instanceId: instanceId)
+        instance?.start()
         //todo: handle starting different instances
         
     }

--- a/PushNotifications/PushNotifications/PushNotificationsStatic.swift
+++ b/PushNotifications/PushNotifications/PushNotificationsStatic.swift
@@ -218,7 +218,6 @@ import Foundation
         } else {
             fatalError("PushNotifications.shared.start must have been called first")
         }
-        return nil
     }
     
     /**
@@ -234,8 +233,6 @@ import Foundation
         } else {
             fatalError("PushNotifications.shared.start must have been called first")
         }
-        return RemoteNotificationType.ShouldProcess
     }
-    
     
 }

--- a/Sources/EventTypeHandler.swift
+++ b/Sources/EventTypeHandler.swift
@@ -13,6 +13,7 @@ struct EventTypeHandler {
         let hasData = EventTypeHandler.hasData(userInfo)
 
         guard
+            let instanceId = InstanceId(userInfo: userInfo).id,
             let publishId = PublishId(userInfo: userInfo).id,
             let deviceId = Device.getDeviceId()
         else {
@@ -24,11 +25,11 @@ struct EventTypeHandler {
 
         switch applicationState {
         case .active:
-            eventType = DeliveryEventType(publishId: publishId, deviceId: deviceId, userId: userId, timestampSecs: timestampSecs, appInBackground: false, hasDisplayableContent: hasDisplayableContent, hasData: hasData)
+            eventType = DeliveryEventType(instanceId: instanceId, publishId: publishId, deviceId: deviceId, userId: userId, timestampSecs: timestampSecs, appInBackground: false, hasDisplayableContent: hasDisplayableContent, hasData: hasData)
         case .background:
-            eventType = DeliveryEventType(publishId: publishId, deviceId: deviceId, userId: userId, timestampSecs: timestampSecs, appInBackground: true, hasDisplayableContent: hasDisplayableContent, hasData: hasData)
+            eventType = DeliveryEventType(instanceId: instanceId, publishId: publishId, deviceId: deviceId, userId: userId, timestampSecs: timestampSecs, appInBackground: true, hasDisplayableContent: hasDisplayableContent, hasData: hasData)
         case .inactive:
-            eventType = OpenEventType(publishId: publishId, deviceId: deviceId, userId: userId, timestampSecs: timestampSecs)
+            eventType = OpenEventType(instanceId: instanceId, publishId: publishId, deviceId: deviceId, userId: userId, timestampSecs: timestampSecs)
         }
 
         return eventType
@@ -41,6 +42,7 @@ struct EventTypeHandler {
         let hasData = EventTypeHandler.hasData(userInfo)
 
         guard
+            let instanceId = InstanceId(userInfo: userInfo).id,
             let publishId = PublishId(userInfo: userInfo).id,
             let deviceId = Device.getDeviceId()
         else {
@@ -52,11 +54,11 @@ struct EventTypeHandler {
 
         switch applicationState {
         case .active:
-            eventType = DeliveryEventType(publishId: publishId, deviceId: deviceId, userId: userId, timestampSecs: timestampSecs, appInBackground: false, hasDisplayableContent: hasDisplayableContent, hasData: hasData)
+            eventType = DeliveryEventType(instanceId: instanceId, publishId: publishId, deviceId: deviceId, userId: userId, timestampSecs: timestampSecs, appInBackground: false, hasDisplayableContent: hasDisplayableContent, hasData: hasData)
         case .background:
-            eventType = DeliveryEventType(publishId: publishId, deviceId: deviceId, userId: userId, timestampSecs: timestampSecs, appInBackground: true, hasDisplayableContent: hasDisplayableContent, hasData: hasData)
+            eventType = DeliveryEventType(instanceId: instanceId, publishId: publishId, deviceId: deviceId, userId: userId, timestampSecs: timestampSecs, appInBackground: true, hasDisplayableContent: hasDisplayableContent, hasData: hasData)
         case .inactive:
-            eventType = OpenEventType(publishId: publishId, deviceId: deviceId, userId: userId, timestampSecs: timestampSecs)
+            eventType = OpenEventType(instanceId: instanceId, publishId: publishId, deviceId: deviceId, userId: userId, timestampSecs: timestampSecs)
         }
 
         return eventType
@@ -66,8 +68,8 @@ struct EventTypeHandler {
     static func getNotificationEventType(userInfo: [AnyHashable: Any]) -> OpenEventType? {
         let timestampSecs = UInt(Date().timeIntervalSince1970)
         guard
-            let publishId = PublishId(userInfo: userInfo).id,
             let instanceId = InstanceId(userInfo: userInfo).id,
+            let publishId = PublishId(userInfo: userInfo).id,
             let deviceId = Device.getDeviceId()
         else {
             return nil

--- a/Tests/IntegrationTests/ApplicationStartTests.swift
+++ b/Tests/IntegrationTests/ApplicationStartTests.swift
@@ -31,7 +31,7 @@ class ApplicationStartTests: XCTestCase {
 
     func testApplicationStartWillSyncInterests() {
         let pushNotifications = PushNotifications(instanceId: instanceId)
-        pushNotifications.start(instanceId: instanceId)
+        pushNotifications.start()
 
         pushNotifications.registerDeviceToken(validToken)
 
@@ -42,7 +42,7 @@ class ApplicationStartTests: XCTestCase {
             .toEventually(equal([]), timeout: 10)
 
         DeviceStateStore.interestsService.persist(interests: ["cucas", "panda", "potato"])
-        pushNotifications.start(instanceId: instanceId)
+        pushNotifications.start()
 
         expect(TestAPIClientHelper().getDeviceInterests(instanceId: self.instanceId, deviceId: deviceId))
             .toEventually(contain("cucas", "panda", "potato"), timeout: 10)

--- a/Tests/IntegrationTests/ClearAllStateTest.swift
+++ b/Tests/IntegrationTests/ClearAllStateTest.swift
@@ -33,7 +33,7 @@ class ClearAllStateTest: XCTestCase {
 
     func testItShouldClearAllState() {
         let pushNotifications = PushNotifications(instanceId: instanceId)
-        pushNotifications.start(instanceId: instanceId)
+        pushNotifications.start()
         pushNotifications.registerDeviceToken(validToken)
 
         expect(Device.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)

--- a/Tests/IntegrationTests/DeviceInterestsTest.swift
+++ b/Tests/IntegrationTests/DeviceInterestsTest.swift
@@ -79,7 +79,7 @@ class DeviceInterestsTest: XCTestCase {
         let pushNotifications = PushNotifications(instanceId: instanceId)
         XCTAssertNoThrow(try pushNotifications.addDeviceInterest(interest: "panda"))
 
-        pushNotifications.start(instanceId: instanceId)
+        pushNotifications.start()
         pushNotifications.registerDeviceToken(validToken)
 
         expect(Device.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
@@ -95,7 +95,7 @@ class DeviceInterestsTest: XCTestCase {
         XCTAssertNoThrow(try pushNotifications.addDeviceInterest(interest: "panda"))
         XCTAssertNoThrow(try pushNotifications.addDeviceInterest(interest: "zebra"))
 
-        pushNotifications.start(instanceId: instanceId)
+        pushNotifications.start()
         pushNotifications.registerDeviceToken(validToken)
 
         expect(Device.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
@@ -131,7 +131,7 @@ class DeviceInterestsTest: XCTestCase {
         })
         pushNotifications2.delegate = stubInterestsChanged
 
-        pushNotifications2.start(instanceId: instanceId)
+        pushNotifications2.start()
         pushNotifications2.registerDeviceToken(validToken)
 
         expect(Device.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)

--- a/Tests/IntegrationTests/SetUserIdTest.swift
+++ b/Tests/IntegrationTests/SetUserIdTest.swift
@@ -34,7 +34,7 @@ class SetUserIdTest: XCTestCase {
 
     func testSetUserIdShouldAssociateThisDeviceWithUserOnTheServer() {
         let pushNotifications = PushNotifications(instanceId: instanceId)
-        pushNotifications.start(instanceId: instanceId)
+        pushNotifications.start()
         pushNotifications.registerDeviceToken(validToken)
 
         expect(Device.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
@@ -49,7 +49,7 @@ class SetUserIdTest: XCTestCase {
 
     func testSetUserIdShouldThrowExceptionIfUserIdIsReassigned() {
         let pushNotifications = PushNotifications(instanceId: instanceId)
-        pushNotifications.start(instanceId: instanceId)
+        pushNotifications.start()
         pushNotifications.registerDeviceToken(validToken)
         let expCucas = expectation(description: "Set user id for cucas should succeed")
         let expPotato = expectation(description: "Set user id for potato should fail")
@@ -70,7 +70,7 @@ class SetUserIdTest: XCTestCase {
 
     func testSetUserIdCallStopAndSettingADifferentUserIdSucceeds() {
         let pushNotifications = PushNotifications(instanceId: instanceId)
-        pushNotifications.start(instanceId: instanceId)
+        pushNotifications.start()
         pushNotifications.registerDeviceToken(validToken)
 
         let tokenProvider = StubTokenProvider(jwt: validCucasJWTToken, error: nil)

--- a/Tests/IntegrationTests/StopTests.swift
+++ b/Tests/IntegrationTests/StopTests.swift
@@ -33,7 +33,7 @@ class StopTests: XCTestCase {
 
     func testStopShouldDeleteDeviceOnTheServer() {
         let pushNotifications = PushNotifications(instanceId: instanceId)
-        pushNotifications.start(instanceId: instanceId)
+        pushNotifications.start()
         pushNotifications.registerDeviceToken(validToken)
 
         expect(Device.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
@@ -52,7 +52,7 @@ class StopTests: XCTestCase {
 
     func testShouldDeleteLocalInterests() {
         let pushNotifications = PushNotifications(instanceId: instanceId)
-        pushNotifications.start(instanceId: instanceId)
+        pushNotifications.start()
         pushNotifications.registerDeviceToken(validToken)
 
         expect(Device.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
@@ -64,7 +64,7 @@ class StopTests: XCTestCase {
 
     func testAfterStopStartingAgainShouldBePossible() {
         let pushNotifications = PushNotifications(instanceId: instanceId)
-        pushNotifications.start(instanceId: instanceId)
+        pushNotifications.start()
         pushNotifications.registerDeviceToken(validToken)
 
         expect(Device.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
@@ -73,7 +73,7 @@ class StopTests: XCTestCase {
 
         expect(Device.getDeviceId()).toEventually(beNil(), timeout: 10)
 
-        pushNotifications.start(instanceId: self.instanceId)
+        pushNotifications.start()
         pushNotifications.registerDeviceToken(validToken)
 
         expect(Device.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)

--- a/Tests/Internal/ServerSyncProcessHandlerTests.swift
+++ b/Tests/Internal/ServerSyncProcessHandlerTests.swift
@@ -858,7 +858,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         serverSyncProcessHandler.jobQueue.append(startJob)
         serverSyncProcessHandler.handleMessage(serverSyncJob: startJob)
 
-        let userInfo = ["aps": ["alert": ["title": "Hello", "body": "Hello, world!"], "content-available": 1], "data": ["pusher": ["publishId": "pubid-33f3f68e-b0c5-438f-b50f-fae93f6c48df"]]]
+        let userInfo = ["aps": ["alert": ["title": "Hello", "body": "Hello, world!"], "content-available": 1], "data": ["pusher": ["instanceId": "8a070eaa-033f-46d6-bb90-f4c15acc47e1", "publishId": "pubid-33f3f68e-b0c5-438f-b50f-fae93f6c48df"]]]
         let eventType = EventTypeHandler.getNotificationEventType(userInfo: userInfo, applicationState: .active) as! DeliveryEventType
 
         let trackEventJob = ServerSyncJob.ReportEventJob(eventType: eventType)

--- a/Tests/Internal/ServerSyncProcessHandlerTests.swift
+++ b/Tests/Internal/ServerSyncProcessHandlerTests.swift
@@ -854,7 +854,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
 
         let startJob = ServerSyncJob.StartJob(instanceId: instanceId, token: deviceToken)
 
-        let serverSyncProcessHandler = ServerSyncProcessHandler(getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
+        let serverSyncProcessHandler = ServerSyncProcessHandler(instanceId: instanceId, getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
         serverSyncProcessHandler.jobQueue.append(startJob)
         serverSyncProcessHandler.handleMessage(serverSyncJob: startJob)
 

--- a/Tests/Internal/ServerSyncProcessHandlerTests.swift
+++ b/Tests/Internal/ServerSyncProcessHandlerTests.swift
@@ -48,7 +48,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         }
 
         let startJob = ServerSyncJob.StartJob(instanceId: instanceId, token: deviceToken)
-        let serverSyncProcessHandler = ServerSyncProcessHandler(getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
+        let serverSyncProcessHandler = ServerSyncProcessHandler(instanceId: instanceId, getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
         serverSyncProcessHandler.jobQueue.append(startJob)
         serverSyncProcessHandler.handleMessage(serverSyncJob: startJob)
 
@@ -79,7 +79,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         }
 
         let startJob = ServerSyncJob.StartJob(instanceId: instanceId, token: deviceToken)
-        let serverSyncProcessHandler = ServerSyncProcessHandler(getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
+        let serverSyncProcessHandler = ServerSyncProcessHandler(instanceId: instanceId, getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
         serverSyncProcessHandler.jobQueue.append(startJob)
         serverSyncProcessHandler.handleMessage(serverSyncJob: startJob)
 
@@ -99,7 +99,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
             return OHHTTPStubsResponse(jsonObject: [], statusCode: 500, headers: nil)
         }
 
-        let serverSyncProcessHandler = ServerSyncProcessHandler(getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
+        let serverSyncProcessHandler = ServerSyncProcessHandler(instanceId: instanceId, getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
         let jobs = [ServerSyncJob.RefreshTokenJob(newToken: "1"), ServerSyncJob.SubscribeJob(interest: "abc", localInterestsChanged: true), ServerSyncJob.UnsubscribeJob(interest: "12", localInterestsChanged: true)]
 
         for job in jobs {
@@ -145,7 +145,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
             return
         }
 
-        let serverSyncProcessHandler = ServerSyncProcessHandler(getTokenProvider: noTokenProvider, handleServerSyncEvent: handleServerSyncEvent)
+        let serverSyncProcessHandler = ServerSyncProcessHandler(instanceId: instanceId, getTokenProvider: noTokenProvider, handleServerSyncEvent: handleServerSyncEvent)
         for job in jobs {
             serverSyncProcessHandler.jobQueue.append(job)
             serverSyncProcessHandler.handleMessage(serverSyncJob: job)
@@ -179,7 +179,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
             ServerSyncJob.StartJob(instanceId: instanceId, token: deviceToken)
         ]
 
-        let serverSyncProcessHandler = ServerSyncProcessHandler(getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
+        let serverSyncProcessHandler = ServerSyncProcessHandler(instanceId: instanceId, getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
         for job in jobs {
             serverSyncProcessHandler.jobQueue.append(job)
             serverSyncProcessHandler.handleMessage(serverSyncJob: job)
@@ -220,7 +220,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         ]
 
 
-        let serverSyncProcessHandler = ServerSyncProcessHandler(getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
+        let serverSyncProcessHandler = ServerSyncProcessHandler(instanceId: instanceId, getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
         for job in jobs {
             serverSyncProcessHandler.jobQueue.append(job)
             serverSyncProcessHandler.handleMessage(serverSyncJob: job)
@@ -259,7 +259,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         ]
 
 
-        let serverSyncProcessHandler = ServerSyncProcessHandler(getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
+        let serverSyncProcessHandler = ServerSyncProcessHandler(instanceId: instanceId, getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
         for job in jobs {
             serverSyncProcessHandler.jobQueue.append(job)
             serverSyncProcessHandler.handleMessage(serverSyncJob: job)
@@ -290,7 +290,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         ]
 
 
-        let serverSyncProcessHandler = ServerSyncProcessHandler(getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
+        let serverSyncProcessHandler = ServerSyncProcessHandler(instanceId: instanceId, getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
         for job in jobs {
             serverSyncProcessHandler.jobQueue.append(job)
             serverSyncProcessHandler.handleMessage(serverSyncJob: job)
@@ -316,7 +316,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         }
 
         let startJob = ServerSyncJob.StartJob(instanceId: instanceId, token: deviceToken)
-        let serverSyncProcessHandler = ServerSyncProcessHandler(getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
+        let serverSyncProcessHandler = ServerSyncProcessHandler(instanceId: instanceId, getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
         serverSyncProcessHandler.jobQueue.append(startJob)
         serverSyncProcessHandler.handleMessage(serverSyncJob: startJob)
 
@@ -373,7 +373,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
             ServerSyncJob.SetSubscriptions(interests: ["1", "2"], localInterestsChanged: true)
         ]
 
-        let serverSyncProcessHandler = ServerSyncProcessHandler(getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
+        let serverSyncProcessHandler = ServerSyncProcessHandler(instanceId: instanceId, getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
         for job in jobs {
             serverSyncProcessHandler.jobQueue.append(job)
             serverSyncProcessHandler.handleMessage(serverSyncJob: job)
@@ -415,7 +415,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         }
 
         let startJob = ServerSyncJob.StartJob(instanceId: instanceId, token: deviceToken)
-        let serverSyncProcessHandler = ServerSyncProcessHandler(getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
+        let serverSyncProcessHandler = ServerSyncProcessHandler(instanceId: instanceId, getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
         serverSyncProcessHandler.jobQueue.append(startJob)
         serverSyncProcessHandler.handleMessage(serverSyncJob: startJob)
 
@@ -462,7 +462,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         DeviceStateStore.usersService.setUserId(userId: "cucas")
 
         let startJob = ServerSyncJob.StartJob(instanceId: instanceId, token: deviceToken)
-        let serverSyncProcessHandler = ServerSyncProcessHandler(getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
+        let serverSyncProcessHandler = ServerSyncProcessHandler(instanceId: instanceId, getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
         serverSyncProcessHandler.jobQueue.append(startJob)
         serverSyncProcessHandler.handleMessage(serverSyncJob: startJob)
 
@@ -502,7 +502,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         let startJob = ServerSyncJob.StartJob(instanceId: instanceId, token: deviceToken)
         let metadata = Metadata(sdkVersion: "123", iosVersion: "11", macosVersion: nil)
         let applicationStartJob = ServerSyncJob.ApplicationStartJob(metadata: metadata)
-        let serverSyncProcessHandler = ServerSyncProcessHandler(getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
+        let serverSyncProcessHandler = ServerSyncProcessHandler(instanceId: instanceId, getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
         serverSyncProcessHandler.jobQueue.append(startJob)
         serverSyncProcessHandler.jobQueue.append(applicationStartJob)
         serverSyncProcessHandler.jobQueue.append(applicationStartJob)
@@ -554,7 +554,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         let startJob = ServerSyncJob.StartJob(instanceId: instanceId, token: deviceToken)
         let metadata = Metadata(sdkVersion: "123", iosVersion: "11", macosVersion: nil)
         let applicationStartJob = ServerSyncJob.ApplicationStartJob(metadata: metadata)
-        let serverSyncProcessHandler = ServerSyncProcessHandler(getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
+        let serverSyncProcessHandler = ServerSyncProcessHandler(instanceId: instanceId, getTokenProvider: noTokenProvider, handleServerSyncEvent: ignoreServerSyncEvent)
         serverSyncProcessHandler.jobQueue.append(startJob)
         serverSyncProcessHandler.jobQueue.append(applicationStartJob)
         serverSyncProcessHandler.jobQueue.append(applicationStartJob)
@@ -595,6 +595,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         let setUserIdJob = ServerSyncJob.SetUserIdJob(userId: "cucas")
         let tokenProvider = StubTokenProvider(jwt: "dummy-jwt", error: nil)
         let serverSyncProcessHandler = ServerSyncProcessHandler(
+            instanceId: instanceId,
             getTokenProvider: { return tokenProvider },
             handleServerSyncEvent: { _ in return }
         )
@@ -633,6 +634,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         let exp = expectation(description: "Callback should be called")
 
         let serverSyncProcessHandler = ServerSyncProcessHandler(
+            instanceId: instanceId,
             getTokenProvider: { return tokenProvider },
             handleServerSyncEvent: { event in
                 switch event {
@@ -673,6 +675,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         let exp = expectation(description: "Callback should be called")
 
         let serverSyncProcessHandler = ServerSyncProcessHandler(
+            instanceId: instanceId,
             getTokenProvider: { return nil },
             handleServerSyncEvent: { event in
                 switch event {
@@ -715,6 +718,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         let exp = expectation(description: "Callback should be called")
 
         let serverSyncProcessHandler = ServerSyncProcessHandler(
+            instanceId: instanceId,
             getTokenProvider: { return tokenProvider },
             handleServerSyncEvent: { event in
                 switch event {
@@ -757,6 +761,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         let exp = expectation(description: "Callback should be called")
 
         let serverSyncProcessHandler = ServerSyncProcessHandler(
+            instanceId: instanceId,
             getTokenProvider: { return tokenProvider },
             handleServerSyncEvent: { event in
                 switch event {
@@ -799,6 +804,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         let exp = expectation(description: "Callback should be called")
 
         let serverSyncProcessHandler = ServerSyncProcessHandler(
+            instanceId: instanceId,
             getTokenProvider: { return tokenProvider },
             handleServerSyncEvent: { event in
                 switch event {


### PR DESCRIPTION
### What?
Refactor the start api to remove the need to pass the instance id as we have it now already
...

#### Why?
We need this to be able to support multi instances of beams in a single app
...

----
CC @pusher/mobile
