### PR TITLE
Multi instance store migration

### DIFF
--- a/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
+++ b/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		D323BB832385AAAE00A618F4 /* InstanceId.swift in Sources */ = {isa = PBXBuildFile; fileRef = D323BB822385AAAE00A618F4 /* InstanceId.swift */; };
 		D37C57232386B0A900F9EA90 /* PersistenceConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37C57222386B0A900F9EA90 /* PersistenceConstants.swift */; };
 		D37C572723882EDF00F9EA90 /* InstanceDeviceStateStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37C572623882EDF00F9EA90 /* InstanceDeviceStateStoreTests.swift */; };
+		D37C5729238BED0700F9EA90 /* DeviceStateStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37C5728238BED0700F9EA90 /* DeviceStateStoreTests.swift */; };
 		D3FBCEA5238555C400CD9B8F /* PushNotificationsStatic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FBCEA4238555C400CD9B8F /* PushNotificationsStatic.swift */; };
 /* End PBXBuildFile section */
 
@@ -173,6 +174,7 @@
 		D323BB822385AAAE00A618F4 /* InstanceId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceId.swift; sourceTree = "<group>"; };
 		D37C57222386B0A900F9EA90 /* PersistenceConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceConstants.swift; sourceTree = "<group>"; };
 		D37C572623882EDF00F9EA90 /* InstanceDeviceStateStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceDeviceStateStoreTests.swift; sourceTree = "<group>"; };
+		D37C5728238BED0700F9EA90 /* DeviceStateStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceStateStoreTests.swift; sourceTree = "<group>"; };
 		D3FBCEA4238555C400CD9B8F /* PushNotificationsStatic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationsStatic.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -226,6 +228,7 @@
 				A108B1022237FE4C007FCB2D /* InterestPersistableTests.swift */,
 				A108B1032237FE4C007FCB2D /* UserPersistableTests.swift */,
 				D37C572623882EDF00F9EA90 /* InstanceDeviceStateStoreTests.swift */,
+				D37C5728238BED0700F9EA90 /* DeviceStateStoreTests.swift */,
 			);
 			name = Persistence;
 			path = ../../Tests/Persistence;
@@ -575,6 +578,7 @@
 				D323BB812385992800A618F4 /* TestHelper.swift in Sources */,
 				A1C41F7B2253B4BC00497D87 /* DeviceRegistrationTests.swift in Sources */,
 				A108B0ED2237FD51007FCB2D /* ReasonTests.swift in Sources */,
+				D37C5729238BED0700F9EA90 /* DeviceStateStoreTests.swift in Sources */,
 				A108B1072237FE4D007FCB2D /* UserPersistableTests.swift in Sources */,
 				A1424C22225E20EA00BCE570 /* ApplicationStartTests.swift in Sources */,
 			);

--- a/Sources/Persistence/PersistenceConstants.swift
+++ b/Sources/Persistence/PersistenceConstants.swift
@@ -10,6 +10,7 @@ struct PersistenceConstants {
             }
         }
         
+        static let globalSuiteName = "PushNotificationsInstances"
         static let metadataSDKVersion = "com.pusher.sdk.metadata.sdkVersion"
         static let metadataiOSVersion = "com.pusher.sdk.metadata.iosVersion"
         static let metadataMacOSVersion = "com.pusher.sdk.metadata.macosVersion"
@@ -19,6 +20,7 @@ struct PersistenceConstants {
     }
 
     struct PersistenceService {
+        static let instanceIdsPrefix = "com.pusher.sdk.instanceIds"
         static let prefix = "com.pusher.sdk.interests"
         static let userId = "com.pusher.sdk.user.id"
         static let hashKey = "interestsHash"

--- a/Tests/IntegrationTests/TestHelper.swift
+++ b/Tests/IntegrationTests/TestHelper.swift
@@ -4,9 +4,9 @@ import Foundation
 struct TestHelper {
     
     static let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
+    static let instanceId2 = "1b880590-6301-4bb5-b34f-45db1c5f5645"
 
     func clearEverything(instanceId: String) {
-        
         if let deviceId = InstanceDeviceStateStore(instanceId).getDeviceId() {
             TestAPIClientHelper().deleteDevice(instanceId: instanceId, deviceId: deviceId)
         }
@@ -16,6 +16,7 @@ struct TestHelper {
         try? FileManager.default.removeItem(atPath:  filePath.relativePath)
         
         InstanceDeviceStateStore(instanceId).clear()
+        DeviceStateStore().removeAllInstanceIds()
     }
     
 }

--- a/Tests/Persistence/DeviceStateStoreTests.swift
+++ b/Tests/Persistence/DeviceStateStoreTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import PushNotifications
+
+class DeviceStateStoreTests : XCTestCase {
+    override func setUp() {
+        super.setUp()
+        TestHelper().clearEverything(instanceId: TestHelper.instanceId)
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        TestHelper().clearEverything(instanceId: TestHelper.instanceId)
+    }
+    
+    func testInstanceIdsShouldRetrieveAndStoreInstancesCorrectly() {
+        let deviceStateStore = DeviceStateStore()
+        XCTAssertEqual(deviceStateStore.getInstanceIds(), [])
+        
+        deviceStateStore.persistInstanceId(TestHelper.instanceId)
+        XCTAssertTrue(deviceStateStore.getInstanceIds().containsSameElements(as: [TestHelper.instanceId]))
+        XCTAssertEqual(deviceStateStore.getInstanceIds().count, 1)
+        
+        // does not have duplicates
+        deviceStateStore.persistInstanceId(TestHelper.instanceId)
+        XCTAssertTrue(deviceStateStore.getInstanceIds().containsSameElements(as: [TestHelper.instanceId]))
+        XCTAssertEqual(deviceStateStore.getInstanceIds().count, 1)
+        
+        // add another instance id
+        deviceStateStore.persistInstanceId(TestHelper.instanceId2)
+        XCTAssertTrue(deviceStateStore.getInstanceIds().containsSameElements(as: [TestHelper.instanceId, TestHelper.instanceId2]))
+        XCTAssertEqual(deviceStateStore.getInstanceIds().count, 2)
+        
+        // remove first instance id
+        deviceStateStore.removeInstanceId(instanceId: TestHelper.instanceId)
+        XCTAssertTrue(deviceStateStore.getInstanceIds().containsSameElements(as: [TestHelper.instanceId2]))
+        XCTAssertEqual(deviceStateStore.getInstanceIds().count, 1)
+        
+        // clear all instances
+        deviceStateStore.removeAllInstanceIds()
+        XCTAssertEqual(deviceStateStore.getInstanceIds(), [])
+    }
+    
+    func testInstnaceIdsShouldMigrateCorrectly() {
+        let oldInstanceService = UserDefaults(suiteName: PersistenceConstants.UserDefaults.suiteName(instanceId: nil))!
+        oldInstanceService.set(TestHelper.instanceId, forKey: PersistenceConstants.UserDefaults.instanceId)
+        
+        // save things to the old storage
+        let oldInstanceStorage = InstanceDeviceStateStore(nil)
+        oldInstanceStorage.persistInterests(["lemon", "pomelo", "grapefruit"])
+        oldInstanceStorage.setUserId(userId: "danielle")
+        oldInstanceStorage.persistServerConfirmedInterestsHash("hash12345")
+        oldInstanceStorage.setStartJobHasBeenEnqueued(flag: true)
+        oldInstanceStorage.setUserIdHasBeenCalledWith(userId: "danielleHasBeenCalled")
+        oldInstanceStorage.persistDeviceId("daniellesDeviceId")
+        oldInstanceStorage.persistAPNsToken(token: "daniellesAPNsToken")
+        oldInstanceStorage.saveMetadata(metadata: Metadata(sdkVersion: "123", iosVersion: "10.0", macosVersion: nil))
+        
+        // get from the new device state store which should handle the migration for us
+        let deviceStateStore = DeviceStateStore()
+        XCTAssertTrue(deviceStateStore.getInstanceIds().containsSameElements(as: [TestHelper.instanceId]))
+        XCTAssertEqual(deviceStateStore.getInstanceIds().count, 1)
+        
+        // assert that the instance storage migrated correctly
+        let newInstanceStorage = InstanceDeviceStateStore(TestHelper.instanceId)
+        XCTAssertTrue(newInstanceStorage.getInterests()!.containsSameElements(as: ["lemon", "pomelo", "grapefruit"]))
+        XCTAssertEqual(newInstanceStorage.getInterests()!.count, 3)
+        XCTAssertEqual(newInstanceStorage.getUserId(), "danielle")
+        XCTAssertEqual(newInstanceStorage.getServerConfirmedInterestsHash(), "hash12345")
+        XCTAssertEqual(newInstanceStorage.getStartJobHasBeenEnqueued(), true)
+        XCTAssertEqual(newInstanceStorage.getUserIdHasBeenCalledWith(), "danielleHasBeenCalled")
+        XCTAssertEqual(newInstanceStorage.getDeviceId(), "daniellesDeviceId")
+        XCTAssertEqual(newInstanceStorage.getAPNsToken(), "daniellesAPNsToken")
+        XCTAssertEqual(newInstanceStorage.loadMetadata().sdkVersion, "123")
+        XCTAssertEqual(newInstanceStorage.loadMetadata().iosVersion, "10.0")
+        XCTAssertEqual(newInstanceStorage.loadMetadata().macosVersion, nil)
+        
+        // assert that old reference is gone
+        XCTAssertEqual(oldInstanceService.string(forKey: PersistenceConstants.UserDefaults.instanceId), nil)
+    }
+}


### PR DESCRIPTION
### What?
We've created a global device state store which handles the migration between the old device state store
...

#### Why?
We need this to support multiple instance ids and handle migrating people gracefully
...

----
CC @pusher/mobile
