### PR TITLE
Multi instance scope server sync process handler

### DIFF
--- a/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
+++ b/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		D37C57232386B0A900F9EA90 /* PersistenceConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37C57222386B0A900F9EA90 /* PersistenceConstants.swift */; };
 		D37C572723882EDF00F9EA90 /* InstanceDeviceStateStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37C572623882EDF00F9EA90 /* InstanceDeviceStateStoreTests.swift */; };
 		D37C5729238BED0700F9EA90 /* DeviceStateStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37C5728238BED0700F9EA90 /* DeviceStateStoreTests.swift */; };
+		D37C572B238D32D700F9EA90 /* MultipleClassInstanceSupportTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37C572A238D32D700F9EA90 /* MultipleClassInstanceSupportTest.swift */; };
+		D37C572D238D353100F9EA90 /* ServerSyncEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37C572C238D353100F9EA90 /* ServerSyncEventHandler.swift */; };
 		D3FBCEA5238555C400CD9B8F /* PushNotificationsStatic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FBCEA4238555C400CD9B8F /* PushNotificationsStatic.swift */; };
 /* End PBXBuildFile section */
 
@@ -173,6 +175,8 @@
 		D37C57222386B0A900F9EA90 /* PersistenceConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceConstants.swift; sourceTree = "<group>"; };
 		D37C572623882EDF00F9EA90 /* InstanceDeviceStateStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceDeviceStateStoreTests.swift; sourceTree = "<group>"; };
 		D37C5728238BED0700F9EA90 /* DeviceStateStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceStateStoreTests.swift; sourceTree = "<group>"; };
+		D37C572A238D32D700F9EA90 /* MultipleClassInstanceSupportTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleClassInstanceSupportTest.swift; sourceTree = "<group>"; };
+		D37C572C238D353100F9EA90 /* ServerSyncEventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSyncEventHandler.swift; sourceTree = "<group>"; };
 		D3FBCEA4238555C400CD9B8F /* PushNotificationsStatic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationsStatic.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -294,6 +298,7 @@
 				A1E80009201A213000467EB9 /* ReportEventType.swift */,
 				A1482A572181F3CD00F19A4E /* Result.swift */,
 				A140FFD62020C5E600931AF6 /* SDK.swift */,
+				D37C572C238D353100F9EA90 /* ServerSyncEventHandler.swift */,
 				A1DAD62D2020CAE7001497B5 /* SystemVersion.swift */,
 				A19B15D22189E4FC008E6DB5 /* Token.swift */,
 				A1327BDE2178EB62001483E1 /* TokenProvider.swift */,
@@ -339,6 +344,7 @@
 				A1424C1D225E061200BCE570 /* ReportEventTypeTests.swift */,
 				A1424C21225E20EA00BCE570 /* ApplicationStartTests.swift */,
 				D323BB802385992800A618F4 /* TestHelper.swift */,
+				D37C572A238D32D700F9EA90 /* MultipleClassInstanceSupportTest.swift */,
 			);
 			name = IntegrationTests;
 			path = ../../Tests/IntegrationTests;
@@ -537,6 +543,7 @@
 				A144AB4F1F9E3DA3009F0040 /* Device.swift in Sources */,
 				A1E8000A201A213000467EB9 /* ReportEventType.swift in Sources */,
 				A1E80015201A3DAC00467EB9 /* PublishId.swift in Sources */,
+				D37C572D238D353100F9EA90 /* ServerSyncEventHandler.swift in Sources */,
 				A1F122E62237C94600F7D766 /* RetryStrategy.swift in Sources */,
 				A16782551FA0EA2D00A193DF /* Reason.swift in Sources */,
 				A108B0CF2237FBF8007FCB2D /* DeviceStateStore.swift in Sources */,
@@ -564,6 +571,7 @@
 				A1424C1E225E061200BCE570 /* ReportEventTypeTests.swift in Sources */,
 				A108B1052237FE4D007FCB2D /* DeviceTests.swift in Sources */,
 				A1D2AC342254E83900AF4871 /* DeviceInterestsTest.swift in Sources */,
+				D37C572B238D32D700F9EA90 /* MultipleClassInstanceSupportTest.swift in Sources */,
 				A108B0F32237FD51007FCB2D /* ConstantsTests.swift in Sources */,
 				A108B0F42237FD51007FCB2D /* ArrayContainsSameElementsTests.swift in Sources */,
 				A108B0EB2237FD51007FCB2D /* FeatureFlagsTests.swift in Sources */,

--- a/PushNotifications/PushNotifications/ServerSyncEventHandler.swift
+++ b/PushNotifications/PushNotifications/ServerSyncEventHandler.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+internal class ServerSyncEventHandler {
+    
+    static let serverSyncEventHandlersQueue = DispatchQueue(label: "serverSyncEventHandlersQueue")
+    static var serverSyncEventHandlers = [String: ServerSyncEventHandler]()
+    
+    static func obtain(instanceId: String) -> ServerSyncEventHandler {
+        serverSyncEventHandlersQueue.sync {
+            if let handler = self.serverSyncEventHandlers[instanceId] {
+                return handler
+            } else {
+                let handler = ServerSyncEventHandler()
+                self.serverSyncEventHandlers[instanceId] = handler
+                return handler
+            }
+        }
+    }
+    
+    // used only for testing purposes
+    internal static func destroy(instanceId: String) {
+        serverSyncEventHandlersQueue.sync {
+            self.serverSyncEventHandlers.removeValue(forKey: instanceId)
+        }
+    }
+    
+    internal var userIdCallbacks = Dictionary<String, [(Error?) -> Void]>()
+    internal var stopCallbacks = [() -> Void]()
+    
+    private var interestsChangedDelegates = [() -> InterestsChangedDelegate?]()
+
+    func handleEvent(event: ServerSyncEvent) {
+        DispatchQueue.main.async {
+            switch event {
+            case .InterestsChangedEvent(let interests):
+                self.interestsChangedDelegates.forEach({ delegate in
+                    if let d = delegate() {
+                        d.interestsSetOnDeviceDidChange(interests: interests)
+                    }
+                })
+                
+            case .UserIdSetEvent(let userId, let error):
+                if !(self.userIdCallbacks[userId]?.isEmpty ?? true) {
+                    if let completion = self.userIdCallbacks[userId]?.removeFirst() {
+                        completion(error)
+                    }
+                }
+            case .StopEvent:
+                if !(self.stopCallbacks.isEmpty) {
+                    let completion = self.stopCallbacks.removeFirst()
+                    completion()
+                }
+            }
+        }
+    }
+    
+    func registerInterestsChangedDelegate(_ interestsChangedDelegate: @escaping () -> InterestsChangedDelegate?) {
+        self.interestsChangedDelegates.append(interestsChangedDelegate)
+    }
+    
+}

--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -11,46 +11,33 @@ import Foundation
     
     private let instanceId: String
     private let deviceStateStore: InstanceDeviceStateStore
+    private let serverSyncEventHandler: ServerSyncEventHandler
+    
+    // The object that acts as the delegate of push notifications.
+    public weak var delegate: InterestsChangedDelegate?
     
     init(instanceId: String) {
         self.instanceId = instanceId
         self.deviceStateStore = InstanceDeviceStateStore(instanceId)
+        self.serverSyncEventHandler = ServerSyncEventHandler.obtain(instanceId: instanceId)
+        
+        super.init()
+        serverSyncEventHandler.registerInterestsChangedDelegate({ [weak self] in return self?.delegate })
+
         DeviceStateStore().persistInstanceId(instanceId)
     }
     
     //! Returns a shared singleton PushNotifications object.
     /// - Tag: shared
     @objc public static let shared = PushNotificationStatic.self
-
-    private var userIdCallbacks = Dictionary<String, [(Error?) -> Void]>()
-    private var stopCallbacks = [() -> Void]()
+    
     private lazy var serverSyncHandler = ServerSyncProcessHandler.obtain(
         instanceId: self.instanceId,
         getTokenProvider: { return PushNotifications.shared.tokenProvider },
         handleServerSyncEvent: { [weak self] (event) in
-            DispatchQueue.main.async {
-                switch event {
-                case .InterestsChangedEvent(let interests):
-                    self?.delegate?.interestsSetOnDeviceDidChange(interests: interests)
-                case .UserIdSetEvent(let userId, let error):
-                    if !(self?.userIdCallbacks[userId]?.isEmpty ?? true) {
-                        if let completion = self?.userIdCallbacks[userId]?.removeFirst() {
-                            completion(error)
-                        }
-                    }
-                case .StopEvent:
-                    if !(self?.stopCallbacks.isEmpty ?? true) {
-                        if let completion = self?.stopCallbacks.removeFirst() {
-                            completion()
-                        }
-                    }
-                }
-            }
+            self?.serverSyncEventHandler.handleEvent(event: event)
         }
     )
-
-    // The object that acts as the delegate of push notifications.
-    public weak var delegate: InterestsChangedDelegate?
 
     private var startHasBeenCalledThisSession = false
 
@@ -152,10 +139,10 @@ import Foundation
             completion(error)
         }
 
-        if let callbacks = self.userIdCallbacks[userId] {
-            self.userIdCallbacks[userId] = callbacks + [wrapperCompletion]
+        if let callbacks = self.serverSyncEventHandler.userIdCallbacks[userId] {
+            self.serverSyncEventHandler.userIdCallbacks[userId] = callbacks + [wrapperCompletion]
         } else {
-            self.userIdCallbacks[userId] = [wrapperCompletion]
+            self.serverSyncEventHandler.userIdCallbacks[userId] = [wrapperCompletion]
         }
         self.serverSyncHandler.sendMessage(serverSyncJob: ServerSyncJob.SetUserIdJob(userId: userId))
     }
@@ -188,7 +175,7 @@ import Foundation
 
         startHasBeenCalledThisSession = false
 
-        self.stopCallbacks.append(completion)
+        self.serverSyncEventHandler.stopCallbacks.append(completion)
         self.serverSyncHandler.sendMessage(serverSyncJob: ServerSyncJob.StopJob)
     }
 
@@ -331,13 +318,12 @@ import Foundation
 
     private func interestsSetOnDeviceDidChange() {
         guard
-            let delegate = delegate,
             let interests = self.getDeviceInterests()
         else {
             return
         }
 
-        return delegate.interestsSetOnDeviceDidChange(interests: interests)
+        self.serverSyncEventHandler.handleEvent(event: .InterestsChangedEvent(interests: interests))
     }
 
     /**

--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -24,7 +24,7 @@ import Foundation
 
     private var userIdCallbacks = Dictionary<String, [(Error?) -> Void]>()
     private var stopCallbacks = [() -> Void]()
-    private lazy var serverSyncHandler = ServerSyncProcessHandler(
+    private lazy var serverSyncHandler = ServerSyncProcessHandler.obtain(
         instanceId: self.instanceId,
         getTokenProvider: { return PushNotifications.shared.tokenProvider },
         handleServerSyncEvent: { [weak self] (event) in

--- a/Tests/IntegrationTests/DeviceInterestsTest.swift
+++ b/Tests/IntegrationTests/DeviceInterestsTest.swift
@@ -77,6 +77,18 @@ class DeviceInterestsTest: XCTestCase {
     }
 
     func testLocalInterestsSetShouldBeMergedAfterDeviceRegistration() {
+        
+        class StubInterestsChanged: InterestsChangedDelegate {
+            let completion: ([String]) -> ()
+            init(completion: @escaping ([String]) -> ()) {
+                self.completion = completion
+            }
+
+            func interestsSetOnDeviceDidChange(interests: [String]) {
+                completion(interests)
+            }
+        }
+        
         // Creating device and setting interests to simulate preexisting device with interests.
         let pushNotifications = PushNotifications(instanceId: instanceId)
         XCTAssertNoThrow(try pushNotifications.addDeviceInterest(interest: "panda"))
@@ -95,32 +107,35 @@ class DeviceInterestsTest: XCTestCase {
         UserDefaults(suiteName: PersistenceConstants.UserDefaults.suiteName(instanceId: self.instanceId)).map { userDefaults in
             Array(userDefaults.dictionaryRepresentation().keys).forEach(userDefaults.removeObject)
         }
+        ServerSyncProcessHandler.destroy(instanceId: instanceId)
+        ServerSyncEventHandler.destroy(instanceId: instanceId)
 
         // Creating new instance to pretend a fresh state
-        ServerSyncProcessHandler.destroy(instanceId: instanceId)
         let pushNotifications2 = PushNotifications(instanceId: instanceId)
         XCTAssertNoThrow(try pushNotifications2.removeDeviceInterest(interest: "panda"))
-        XCTAssertNoThrow(try pushNotifications2.addDeviceInterest(interest: "lion"))
-
-        class StubInterestsChanged: InterestsChangedDelegate {
-            let completion: ([String]) -> ()
-            init(completion: @escaping ([String]) -> ()) {
-                self.completion = completion
-            }
-
-            func interestsSetOnDeviceDidChange(interests: [String]) {
-                completion(interests)
-            }
-        }
-        let exp = expectation(description: "Interests changed called with ['zebra', 'lion']")
+        
+        let exp = expectation(description: "Interests changed called with ['lion']")
         let stubInterestsChanged = StubInterestsChanged(completion: { interests in
-            XCTAssertTrue(interests.containsSameElements(as: ["zebra", "lion"]))
+            XCTAssertTrue(interests.containsSameElements(as: ["lion"]))
             exp.fulfill()
         })
+
         pushNotifications2.delegate = stubInterestsChanged
+
+        XCTAssertNoThrow(try pushNotifications2.addDeviceInterest(interest: "lion"))
+        waitForExpectations(timeout: 10)
+        
+
+        let exp2 = expectation(description: "Interests changed called with ['zebra', 'lion']")
+        let stubInterestsChanged2 = StubInterestsChanged(completion: { interests in
+            XCTAssertTrue(interests.containsSameElements(as: ["zebra", "lion"]))
+            exp2.fulfill()
+        })
+        pushNotifications2.delegate = stubInterestsChanged2
 
         pushNotifications2.start()
         pushNotifications2.registerDeviceToken(validToken)
+        waitForExpectations(timeout: 10)
 
         expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
         let deviceId2 = self.deviceStateStore.getDeviceId()!
@@ -128,7 +143,6 @@ class DeviceInterestsTest: XCTestCase {
 
         expect(TestAPIClientHelper().getDeviceInterests(instanceId: self.instanceId, deviceId: deviceId2))
             .toEventually(contain("zebra", "lion"), timeout: 10)
-        waitForExpectations(timeout: 1)
     }
 
     func testInterestsSetDidChangeAndCallbackIsCalled() {

--- a/Tests/IntegrationTests/DeviceInterestsTest.swift
+++ b/Tests/IntegrationTests/DeviceInterestsTest.swift
@@ -97,6 +97,7 @@ class DeviceInterestsTest: XCTestCase {
         }
 
         // Creating new instance to pretend a fresh state
+        ServerSyncProcessHandler.destroy(instanceId: instanceId)
         let pushNotifications2 = PushNotifications(instanceId: instanceId)
         XCTAssertNoThrow(try pushNotifications2.removeDeviceInterest(interest: "panda"))
         XCTAssertNoThrow(try pushNotifications2.addDeviceInterest(interest: "lion"))

--- a/Tests/IntegrationTests/MultipleClassInstanceSupportTest.swift
+++ b/Tests/IntegrationTests/MultipleClassInstanceSupportTest.swift
@@ -1,0 +1,99 @@
+import XCTest
+import Nimble
+@testable import PushNotifications
+
+class MultipleClassInstanceSupportTest: XCTestCase {
+    let validToken = "notadevicetoken-apns-MultipleClassInstanceSupportTest".data(using: .utf8)!
+    let deviceStateStore = InstanceDeviceStateStore(TestHelper.instanceId)
+    let validCucasJWTToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjQ3MDc5OTIzMDIsImlzcyI6Imh0dHBzOi8vMWI4ODA1OTAtNjMwMS00YmI1LWIzNGYtNDVkYjFjNWY1NjQ0LnB1c2hub3RpZmljYXRpb25zLnB1c2hlci5jb20iLCJzdWIiOiJjdWNhcyJ9.CTtrDXh7vae3rSSKBKf5X0y4RQpFg7YvIlirmBQqJn4"
+    
+    override func setUp() {
+        super.setUp()
+        TestHelper.clearEverything(instanceId: TestHelper.instanceId)
+    }
+    
+    override func tearDown() {
+        TestHelper.clearEverything(instanceId: TestHelper.instanceId)
+        super.tearDown()
+    }
+    
+    func testStopCallbacksShouldCallOnTheRightCallback() {
+        let pushNotifications1 = PushNotifications(instanceId: TestHelper.instanceId)
+        let pushNotifications2 = PushNotifications(instanceId: TestHelper.instanceId)
+        
+        pushNotifications1.start()
+        pushNotifications1.registerDeviceToken(validToken)
+        
+        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        let deviceId = self.deviceStateStore.getDeviceId()!
+        
+        let exp = expectation(description: "Stop completion handler must be called")
+        pushNotifications2.stop {
+            exp.fulfill()
+        }
+        
+        expect(TestAPIClientHelper().getDevice(instanceId: TestHelper.instanceId, deviceId: deviceId))
+            .toEventually(beNil(), timeout: 10)
+        
+        waitForExpectations(timeout: 1)
+    }
+    
+    func testSetUserIdsCalledOnCorrectCallback () {
+        let pushNotifications1 = PushNotifications(instanceId: TestHelper.instanceId)
+        let pushNotifications2 = PushNotifications(instanceId: TestHelper.instanceId)
+        
+        pushNotifications1.start()
+        pushNotifications2.start()
+        pushNotifications1.registerDeviceToken(validToken)
+        
+        let tokenProvider = StubTokenProvider(jwt: validCucasJWTToken, error: nil)
+        let exp = expectation(description: "It should not return an error")
+        pushNotifications2.setUserId("cucas", tokenProvider: tokenProvider) { error in
+            XCTAssertNil(error)
+            exp.fulfill()
+        }
+        
+        waitForExpectations(timeout: 10)
+    }
+    
+    func testInterestsChangedDelegateCalledOnCorrectCallback() {
+        let pushNotifications1 = PushNotifications(instanceId: TestHelper.instanceId)
+        let pushNotifications2 = PushNotifications(instanceId: TestHelper.instanceId)
+        
+        class StubInterestsChanged: InterestsChangedDelegate {
+            let completion: ([String]) -> ()
+            init(completion: @escaping ([String]) -> ()) {
+                self.completion = completion
+            }
+
+            func interestsSetOnDeviceDidChange(interests: [String]) {
+                completion(interests)
+            }
+        }
+        let exp = expectation(description: "Interests changed called with ['panda']")
+        let stubInterestsChanged = StubInterestsChanged(completion: { interests in
+            XCTAssertTrue(interests.containsSameElements(as: ["panda"]))
+            exp.fulfill()
+        })
+        pushNotifications1.delegate = stubInterestsChanged
+        
+        XCTAssertNoThrow(try! pushNotifications2.addDeviceInterest(interest: "panda"))
+
+        waitForExpectations(timeout: 1)
+    }
+    
+    class StubTokenProvider: TokenProvider {
+        private let jwt: String
+        private let error: Error?
+        
+        init(jwt: String, error: Error?) {
+            self.jwt = jwt
+            self.error = error
+        }
+        
+        func fetchToken(userId: String, completionHandler completion: @escaping (String, Error?) -> Void) throws {
+            completion(jwt, error)
+        }
+    }
+    
+}

--- a/Tests/IntegrationTests/TestHelper.swift
+++ b/Tests/IntegrationTests/TestHelper.swift
@@ -17,6 +17,7 @@ struct TestHelper {
         
         InstanceDeviceStateStore(instanceId).clear()
         DeviceStateStore().removeAllInstanceIds()
+        ServerSyncProcessHandler.destroy(instanceId: instanceId)
     }
     
 }

--- a/Tests/IntegrationTests/TestHelper.swift
+++ b/Tests/IntegrationTests/TestHelper.swift
@@ -18,6 +18,6 @@ struct TestHelper {
         InstanceDeviceStateStore(instanceId).clear()
         DeviceStateStore().removeAllInstanceIds()
         ServerSyncProcessHandler.destroy(instanceId: instanceId)
+        ServerSyncEventHandler.destroy(instanceId: instanceId)
     }
-    
 }


### PR DESCRIPTION
### What?
We created a ServerSyncEventHandler to add callbacks to which means it should call the correct instance
...

#### Why?
We need to be able to call back on the right callback when we allow for multiple instanceids
...

----
CC @pusher/mobile
