### PR TITLE
Scope token provider by instance id

### DIFF
--- a/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
+++ b/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		D37C5729238BED0700F9EA90 /* DeviceStateStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37C5728238BED0700F9EA90 /* DeviceStateStoreTests.swift */; };
 		D37C572B238D32D700F9EA90 /* MultipleClassInstanceSupportTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37C572A238D32D700F9EA90 /* MultipleClassInstanceSupportTest.swift */; };
 		D37C572D238D353100F9EA90 /* ServerSyncEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37C572C238D353100F9EA90 /* ServerSyncEventHandler.swift */; };
+		D37C572F238D681F00F9EA90 /* MultipleInstanceSupportTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37C572E238D681F00F9EA90 /* MultipleInstanceSupportTest.swift */; };
 		D3FBCEA5238555C400CD9B8F /* PushNotificationsStatic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FBCEA4238555C400CD9B8F /* PushNotificationsStatic.swift */; };
 /* End PBXBuildFile section */
 
@@ -177,6 +178,7 @@
 		D37C5728238BED0700F9EA90 /* DeviceStateStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceStateStoreTests.swift; sourceTree = "<group>"; };
 		D37C572A238D32D700F9EA90 /* MultipleClassInstanceSupportTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleClassInstanceSupportTest.swift; sourceTree = "<group>"; };
 		D37C572C238D353100F9EA90 /* ServerSyncEventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSyncEventHandler.swift; sourceTree = "<group>"; };
+		D37C572E238D681F00F9EA90 /* MultipleInstanceSupportTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleInstanceSupportTest.swift; sourceTree = "<group>"; };
 		D3FBCEA4238555C400CD9B8F /* PushNotificationsStatic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationsStatic.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -345,6 +347,7 @@
 				A1424C21225E20EA00BCE570 /* ApplicationStartTests.swift */,
 				D323BB802385992800A618F4 /* TestHelper.swift */,
 				D37C572A238D32D700F9EA90 /* MultipleClassInstanceSupportTest.swift */,
+				D37C572E238D681F00F9EA90 /* MultipleInstanceSupportTest.swift */,
 			);
 			name = IntegrationTests;
 			path = ../../Tests/IntegrationTests;
@@ -572,6 +575,7 @@
 				A108B1052237FE4D007FCB2D /* DeviceTests.swift in Sources */,
 				A1D2AC342254E83900AF4871 /* DeviceInterestsTest.swift in Sources */,
 				D37C572B238D32D700F9EA90 /* MultipleClassInstanceSupportTest.swift in Sources */,
+				D37C572F238D681F00F9EA90 /* MultipleInstanceSupportTest.swift in Sources */,
 				A108B0F32237FD51007FCB2D /* ConstantsTests.swift in Sources */,
 				A108B0F42237FD51007FCB2D /* ArrayContainsSameElementsTests.swift in Sources */,
 				A108B0EB2237FD51007FCB2D /* FeatureFlagsTests.swift in Sources */,

--- a/PushNotifications/PushNotifications/PushNotificationsStatic.swift
+++ b/PushNotifications/PushNotifications/PushNotificationsStatic.swift
@@ -14,7 +14,7 @@ import Foundation
     }
     
     private static var instance: PushNotifications?
-    internal static var tokenProvider: TokenProvider?
+    internal static var tokenProvider = Dictionary<String, TokenProvider>()
     
     /**
      Start PushNotifications service.

--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -33,7 +33,7 @@ import Foundation
     
     private lazy var serverSyncHandler = ServerSyncProcessHandler.obtain(
         instanceId: self.instanceId,
-        getTokenProvider: { return PushNotifications.shared.tokenProvider },
+        getTokenProvider: { return PushNotifications.shared.tokenProvider[self.instanceId] },
         handleServerSyncEvent: { [weak self] (event) in
             self?.serverSyncEventHandler.handleEvent(event: event)
         }
@@ -109,7 +109,7 @@ import Foundation
             return
         }
 
-        PushNotifications.shared.tokenProvider = tokenProvider
+        PushNotifications.shared.tokenProvider[self.instanceId] = tokenProvider
 
         var localUserIdDifferent: Bool?
         InstanceDeviceStateStore.synchronize {

--- a/Tests/IntegrationTests/MultipleInstanceSupportTest.swift
+++ b/Tests/IntegrationTests/MultipleInstanceSupportTest.swift
@@ -1,0 +1,72 @@
+import XCTest
+import Nimble
+@testable import PushNotifications
+
+class MultipleInstanceSupportTest: XCTestCase {
+    
+    let validCucasToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjQ3MDc5OTIzMDIsImlzcyI6Imh0dHBzOi8vMWI4ODA1OTAtNjMwMS00YmI1LWIzNGYtNDVkYjFjNWY1NjQ0LnB1c2hub3RpZmljYXRpb25zLnB1c2hlci5jb20iLCJzdWIiOiJjdWNhcyJ9.CTtrDXh7vae3rSSKBKf5X0y4RQpFg7YvIlirmBQqJn4"
+    let validJessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjQ3MDc5OTIzMDIsImlzcyI6Imh0dHBzOi8vOGJhNzZkYWMtYjJkZS00NzJmLWJjZjItNzRjY2E0MzhlYTEzLnB1c2hub3RpZmljYXRpb25zLnB1c2hlci5jb20iLCJzdWIiOiJqZXNzIn0.1x2qaxoOtMuz6CYxLOdySUjm7ivSH6AKkRqNmCqWe9o"
+    let validAPNsToken = "notadevicetoken-apns-SetUserIdTest".data(using: .utf8)!
+
+    override func setUp() {
+        super.setUp()
+        TestHelper.clearEverything(instanceId: TestHelper.instanceId)
+        TestHelper.clearEverything(instanceId: TestHelper.instanceId2)
+    }
+    
+    override func tearDown() {
+        TestHelper.clearEverything(instanceId: TestHelper.instanceId)
+        TestHelper.clearEverything(instanceId: TestHelper.instanceId2)
+        super.tearDown()
+    }
+       
+    func testSetUserIdShouldNotAffectTheOther() {
+        let tokenProvider1 = StubTokenProvider(jwt: validCucasToken, error: nil)
+        let tokenProvider2 = StubTokenProvider(jwt: validJessToken, error: nil)
+        
+        let pni1 = PushNotifications(instanceId: TestHelper.instanceId)
+        let pni2 = PushNotifications(instanceId: TestHelper.instanceId2)
+        
+        pni1.start()
+        pni2.start()
+        
+        pni1.registerDeviceToken(validAPNsToken)
+        pni2.registerDeviceToken(validAPNsToken)
+        
+        let expCucas = expectation(description: "Set user id for cucas should succeed")
+        pni1.setUserId("cucas", tokenProvider: tokenProvider1) { error in
+            XCTAssertNil(error)
+            expCucas.fulfill()
+        }
+        waitForExpectations(timeout: 10)
+        
+        let expJess = expectation(description: "Set user id for jess should succeed")
+        pni2.setUserId("jess", tokenProvider: tokenProvider2) { error in
+            XCTAssertNil(error)
+            expJess.fulfill()
+        }
+        waitForExpectations(timeout: 10)
+        
+        let deviceId1 = InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()!
+        let deviceId2 = InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()!
+
+        expect(TestAPIClientHelper().getDevice(instanceId: TestHelper.instanceId, deviceId: deviceId1)?.userId)
+            .toEventually(equal("cucas"), timeout: 30)
+        expect(TestAPIClientHelper().getDevice(instanceId: TestHelper.instanceId2, deviceId: deviceId2)?.userId)
+        .toEventually(equal("jess"), timeout: 30)
+    }
+    
+    class StubTokenProvider: TokenProvider {
+        private let jwt: String
+        private let error: Error?
+
+        init(jwt: String, error: Error?) {
+            self.jwt = jwt
+            self.error = error
+        }
+
+        func fetchToken(userId: String, completionHandler completion: @escaping (String, Error?) -> Void) throws {
+            completion(jwt, error)
+        }
+    }
+}

--- a/Tests/IntegrationTests/TestHelper.swift
+++ b/Tests/IntegrationTests/TestHelper.swift
@@ -4,7 +4,7 @@ import Foundation
 struct TestHelper {
     
     static let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
-    static let instanceId2 = "1b880590-6301-4bb5-b34f-45db1c5f5645"
+    static let instanceId2 = "8ba76dac-b2de-472f-bcf2-74cca438ea13"
 
     static func clearEverything(instanceId: String) {
         if let deviceId = InstanceDeviceStateStore(instanceId).getDeviceId() {


### PR DESCRIPTION
### What?
We've scoped the token provider by instance id so that each instance has it's own token provider
...

#### Why?
We need this for multi instance support
...

----
CC @pusher/mobile
