### PR TITLE
Multi instance register device token

### DIFF
--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -60,6 +60,7 @@ import Foundation
         }
 
         startHasBeenCalledThisSession = true
+        deviceStateStore.persistStartJobHasBeenEnqueued(flag: true)
         self.serverSyncHandler.sendMessage(serverSyncJob: .ApplicationStartJob(metadata: Metadata.getCurrent()))
     }
 
@@ -211,15 +212,7 @@ import Foundation
      */
     /// - Tag: registerDeviceToken
     @objc public func registerDeviceToken(_ deviceToken: Data) {
-        if !startHasBeenCalledThisSession {
-            print("[PushNotifications] - Something went wrong. Please make sure that you've called `start` before `registerDeviceToken`.")
-            return
-        }
-
-        self.deviceStateStore.persistAPNsToken(token: deviceToken.hexadecimalRepresentation())
-
-        // TODO: Handle Token Refresh support
-        self.serverSyncHandler.sendMessage(serverSyncJob: ServerSyncJob.StartJob(instanceId: instanceId, token: deviceToken.hexadecimalRepresentation()))
+        PushNotificationStatic.registerDeviceToken(deviceToken)
     }
 
     /**

--- a/Tests/IntegrationTests/DeviceRegistrationTests.swift
+++ b/Tests/IntegrationTests/DeviceRegistrationTests.swift
@@ -18,8 +18,8 @@ class DeviceRegistrationTests: XCTestCase {
     }
 
     func testStartRegisterDeviceTokenResultsInDeviceIdBeingStored() {
-        let pushNotifications = PushNotifications.shared
-        pushNotifications.start(instanceId: instanceId)
+        let pushNotifications = PushNotifications(instanceId: instanceId)
+        pushNotifications.start()
 
         pushNotifications.registerDeviceToken(validToken)
 

--- a/Tests/IntegrationTests/MultipleInstanceSupportTest.swift
+++ b/Tests/IntegrationTests/MultipleInstanceSupportTest.swift
@@ -56,6 +56,19 @@ class MultipleInstanceSupportTest: XCTestCase {
         .toEventually(equal("jess"), timeout: 30)
     }
     
+    func testMultipleDeviceTokenRegistrationAffectsAllStartedInstances() {
+        let pni1 = PushNotifications(instanceId: TestHelper.instanceId)
+        let pni2 = PushNotifications(instanceId: TestHelper.instanceId2)
+        
+        pni1.start()
+        pni2.start()
+        
+        pni1.registerDeviceToken(validAPNsToken)
+        
+        expect(InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+    }
+    
     class StubTokenProvider: TokenProvider {
         private let jwt: String
         private let error: Error?

--- a/Tests/IntegrationTests/ReportEventTypeTests.swift
+++ b/Tests/IntegrationTests/ReportEventTypeTests.swift
@@ -18,8 +18,8 @@ class ReportEventTypeTests: XCTestCase {
     }
 
     func testHandleNotification() {
-        let pushNotifications = PushNotifications.shared
-        pushNotifications.start(instanceId: instanceId)
+        let pushNotifications = PushNotifications(instanceId: instanceId)
+        pushNotifications.start()
 
         pushNotifications.registerDeviceToken(validToken)
 


### PR DESCRIPTION
### What?
Ensure that if the register device token is received, that all instances that have been started get that change
...

#### Why?
We need this for multiple instance support
...

----
CC @pusher/mobile
