### PR TITLE
In clear all check we've actually started the instance using the devi…

### DIFF
--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -190,7 +190,7 @@ import Foundation
     /// - Tag: clearAllState
     @objc public func clearAllState(completion: @escaping () -> Void) {
         let storedAPNsToken = self.deviceStateStore.getAPNsToken()
-        let hasStartAlreadyBeenCalled = self.startHasBeenCalledThisSession
+        let hasStartAlreadyBeenCalled = self.deviceStateStore.getStartJobHasBeenEnqueued()
         self.stop(completion: completion)
 
         if hasStartAlreadyBeenCalled {

--- a/Tests/IntegrationTests/MultipleClassInstanceSupportTest.swift
+++ b/Tests/IntegrationTests/MultipleClassInstanceSupportTest.swift
@@ -82,6 +82,21 @@ class MultipleClassInstanceSupportTest: XCTestCase {
         waitForExpectations(timeout: 1)
     }
     
+    func testClearAllOnSameInstanceWorks() {
+        let pushNotifications1 = PushNotifications(instanceId: TestHelper.instanceId)
+        let pushNotifications2 = PushNotifications(instanceId: TestHelper.instanceId)
+        
+        pushNotifications1.start()
+        pushNotifications1.registerDeviceToken(validToken)
+
+        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        let deviceId = self.deviceStateStore.getDeviceId()!
+        
+        pushNotifications2.clearAllState { }
+        
+        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(be(deviceId), timeout: 10)
+    }
+    
     class StubTokenProvider: TokenProvider {
         private let jwt: String
         private let error: Error?


### PR DESCRIPTION
…ce state store variable

### What?
In clear all, we want to use the device state store variable to check if we've been started
...

#### Why?
To preserve previous api 
...

----
CC @pusher/mobile
