### PR TITLE
Fix missing instance id issue

### DIFF
--- a/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
+++ b/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		A1F122E42237C90600F7D766 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F122E22237C90500F7D766 /* NetworkService.swift */; };
 		A1F122E62237C94600F7D766 /* RetryStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F122E52237C94600F7D766 /* RetryStrategy.swift */; };
 		A1F122E82237C9D400F7D766 /* PushNotificationsAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F122E72237C9D400F7D766 /* PushNotificationsAPIError.swift */; };
+		D30750BA239919D5008F0C53 /* ServerSyncJobStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30750B9239919D5008F0C53 /* ServerSyncJobStoreTests.swift */; };
 		D323BB812385992800A618F4 /* TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D323BB802385992800A618F4 /* TestHelper.swift */; };
 		D323BB832385AAAE00A618F4 /* InstanceId.swift in Sources */ = {isa = PBXBuildFile; fileRef = D323BB822385AAAE00A618F4 /* InstanceId.swift */; };
 		D37C57232386B0A900F9EA90 /* PersistenceConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37C57222386B0A900F9EA90 /* PersistenceConstants.swift */; };
@@ -171,6 +172,7 @@
 		A1F122E22237C90500F7D766 /* NetworkService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		A1F122E52237C94600F7D766 /* RetryStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryStrategy.swift; sourceTree = "<group>"; };
 		A1F122E72237C9D400F7D766 /* PushNotificationsAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationsAPIError.swift; sourceTree = "<group>"; };
+		D30750B9239919D5008F0C53 /* ServerSyncJobStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSyncJobStoreTests.swift; sourceTree = "<group>"; };
 		D323BB802385992800A618F4 /* TestHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelper.swift; sourceTree = "<group>"; };
 		D323BB822385AAAE00A618F4 /* InstanceId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceId.swift; sourceTree = "<group>"; };
 		D37C57222386B0A900F9EA90 /* PersistenceConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceConstants.swift; sourceTree = "<group>"; };
@@ -232,6 +234,7 @@
 				A108B1032237FE4C007FCB2D /* UserPersistableTests.swift */,
 				D37C572623882EDF00F9EA90 /* InstanceDeviceStateStoreTests.swift */,
 				D37C5728238BED0700F9EA90 /* DeviceStateStoreTests.swift */,
+				D30750B9239919D5008F0C53 /* ServerSyncJobStoreTests.swift */,
 			);
 			name = Persistence;
 			path = ../../Tests/Persistence;
@@ -565,6 +568,7 @@
 				D37C572723882EDF00F9EA90 /* InstanceDeviceStateStoreTests.swift in Sources */,
 				A108B0F02237FD51007FCB2D /* BeamsTokenProviderTests.swift in Sources */,
 				A108B1062237FE4D007FCB2D /* InterestPersistableTests.swift in Sources */,
+				D30750BA239919D5008F0C53 /* ServerSyncJobStoreTests.swift in Sources */,
 				A1D2AC3C22560A4300AF4871 /* ClearAllStateTest.swift in Sources */,
 				A108B0F62237FD51007FCB2D /* SDKTests.swift in Sources */,
 				A1D2AC362254EF0900AF4871 /* TestAPIClientHelper.swift in Sources */,

--- a/Sources/ServerSyncJob.swift
+++ b/Sources/ServerSyncJob.swift
@@ -38,6 +38,10 @@ extension ServerSyncJob: Codable {
         case openEventTypeKey
         case deliveryEventTypeKey
     }
+    
+    private enum ServerSyncJobError: Error {
+        case ParseError(reason: String)
+    }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -85,7 +89,8 @@ extension ServerSyncJob: Codable {
                 self = .ReportEventJob(eventType: deliveryEventType)
                 return
             }
-            self = .ReportEventJob(eventType: OpenEventType.init(instanceId: "", publishId: "", deviceId: "", userId: "", timestampSecs: 0))
+            
+            throw ServerSyncJobError.ParseError(reason: "Issue with the report event")
         case .StopJobKey:
             self = .StopJob
             return

--- a/Tests/EventTypeHandlerTests.swift
+++ b/Tests/EventTypeHandlerTests.swift
@@ -143,4 +143,16 @@ class EventTypeHandlerTests: XCTestCase {
         let remoteNotificationType = EventTypeHandler.getRemoteNotificationType(userInfo)
         XCTAssertTrue(remoteNotificationType == .ShouldProcess)
     }
+    
+    func testMissingInstanceIdReturnsNil() {
+        let userInfo = ["aps": ["content-available": 1], "data": ["pusher": ["publishId": "pubid-33f3f68e-b0c5-438f-b50f-fae93f6c48df", "userId": nil]]]
+        let eventType = EventTypeHandler.getNotificationEventType(userInfo: userInfo)
+        XCTAssertNil(eventType)
+    }
+    
+    func testMissingPublishIdReturnsNil() {
+        let userInfo = ["aps": ["content-available": 1], "data": ["pusher": ["instanceId": "1b880590-6301-4bb5-b34f-45db1c5f5644", "userId": nil]]]
+        let eventType = EventTypeHandler.getNotificationEventType(userInfo: userInfo)
+        XCTAssertNil(eventType)
+    }
 }

--- a/Tests/EventTypeHandlerTests.swift
+++ b/Tests/EventTypeHandlerTests.swift
@@ -128,7 +128,6 @@ class EventTypeHandlerTests: XCTestCase {
         XCTAssertNil(eventType.userId)
         XCTAssertEqual(eventType.userId, nil)
     }
-    #endif
 
     func testItIsInternalNotification() {
         let userInfo = ["aps" : ["alert": ["title": "Hello", "body": "Hello, world!"], "content-available": 1], "data": ["pusher": ["instanceId": "1b880590-6301-4bb5-b34f-45db1c5f5644", "publishId": "pubid-33f3f68e-b0c5-438f-b50f-fae93f6c48df", "userShouldIgnore": true]]]
@@ -155,4 +154,5 @@ class EventTypeHandlerTests: XCTestCase {
         let eventType = EventTypeHandler.getNotificationEventType(userInfo: userInfo)
         XCTAssertNil(eventType)
     }
+    #endif
 }

--- a/Tests/Persistence/ServerSyncJobStoreTests.swift
+++ b/Tests/Persistence/ServerSyncJobStoreTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import PushNotifications
+
+class ServerSyncJobStoreTests : XCTestCase {
+    override func setUp() {
+        super.setUp()
+        TestHelper.clearEverything(instanceId: TestHelper.instanceId)
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        TestHelper.clearEverything(instanceId: TestHelper.instanceId)
+    }
+    
+    
+    func testBasicOperations() {
+        var jobstore = ServerSyncJobStore()
+
+        XCTAssertTrue(jobstore.isEmpty)
+        
+        jobstore.append(.SetUserIdJob(userId: "danielle"))
+            
+        XCTAssertFalse(jobstore.isEmpty)
+        
+        let list = jobstore.toList()
+        XCTAssertEqual(list.count, 1)
+        
+        if case .SetUserIdJob(let userId) = list[0] {
+            XCTAssertEqual(userId, "danielle")
+        } else {
+            XCTFail()
+        }
+        
+        let firstElement = jobstore.first
+        if case .SetUserIdJob(let userId) = firstElement {
+            XCTAssertEqual(userId, "danielle")
+        } else {
+            XCTFail()
+        }
+        
+        jobstore.removeFirst()
+        
+        XCTAssertTrue(jobstore.isEmpty)
+        XCTAssertEqual(jobstore.toList().count, 0)
+    }
+    
+
+    func testCorruptedFileShouldReturnEmptyOperations() {
+        // create the file manually
+        let url = try! FileManager.default.url(for: .libraryDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+        let filePath = url.appendingPathComponent("syncJobStore")
+        let contents = "[invalid_json // lol]"
+        try? FileManager.default.createFile(atPath: filePath.relativePath, contents: contents.toData()!)
+        
+        let jobstore = ServerSyncJobStore()
+        
+        XCTAssertTrue(jobstore.isEmpty)
+        XCTAssertEqual(jobstore.toList().count, 0)
+    }
+    
+    func testCorruptedEventShouldDropAllRequests() {
+        let url = try! FileManager.default.url(for: .libraryDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+        let filePath = url.appendingPathComponent("syncJobStore")
+        let contents = "[{\"userIdKey\":\"danielle\",\"discriminator\":6},{\"discriminator\":7000}]"
+        try? FileManager.default.createFile(atPath: filePath.relativePath, contents: contents.toData()!)
+        
+        var jobstore = ServerSyncJobStore()
+        XCTAssertTrue(jobstore.isEmpty)
+        XCTAssertEqual(jobstore.toList().count, 0)
+    }
+    
+}


### PR DESCRIPTION
### What?
We fixed the server sync job decoder to not fail all jobs if one job fails.
...

#### Why?
We need to ensure that the server sync jobs work correctly if one reporting job is missing the instance id
...

----
CC @pusher/mobile
