### PR TITLE
Scope the server sync job store file by instance id

### DIFF
--- a/Sources/Internal/ServerSyncProcessHandler.swift
+++ b/Sources/Internal/ServerSyncProcessHandler.swift
@@ -34,7 +34,7 @@ class ServerSyncProcessHandler {
     private let networkService: NetworkService
     private let getTokenProvider: () -> TokenProvider?
     private let handleServerSyncEvent: (ServerSyncEvent) -> Void
-    public var jobQueue: ServerSyncJobStore = ServerSyncJobStore()
+    public var jobQueue: ServerSyncJobStore
     private let deviceStateStore: InstanceDeviceStateStore
 
     internal init(instanceId: String, getTokenProvider: @escaping () -> TokenProvider?, handleServerSyncEvent: @escaping (ServerSyncEvent) -> Void) {
@@ -46,6 +46,7 @@ class ServerSyncProcessHandler {
         self.handleMessageQueue = DispatchQueue(label: "handleMessageQueue")
         let session = URLSession(configuration: .ephemeral)
         self.networkService = NetworkService(session: session)
+        self.jobQueue = ServerSyncJobStore(instanceId: self.instanceId)
 
         self.jobQueue.toList().forEach { job in
             switch job {

--- a/Sources/Persistence/ServerSyncJobStore.swift
+++ b/Sources/Persistence/ServerSyncJobStore.swift
@@ -1,12 +1,16 @@
 import Foundation
 
 struct ServerSyncJobStore {
-    private let syncJobStoreFileName = "syncJobStore"
+    private let instanceId: String
+    private let syncJobStoreFileName: String
     private let fileManager = FileManager.default
     private var jobStoreArray: [ServerSyncJob] = []
     private let syncJobStoreQueue = DispatchQueue(label: "syncJobStoreQueue")
 
-    init() {
+    init(instanceId: String) {
+        self.instanceId = instanceId
+        self.syncJobStoreFileName = "\(self.instanceId)-syncJobStore"
+        
         self.jobStoreArray = self.loadOperations()
     }
 

--- a/Tests/IntegrationTests/TestHelper.swift
+++ b/Tests/IntegrationTests/TestHelper.swift
@@ -12,7 +12,7 @@ struct TestHelper {
         }
         
         let url = try! FileManager.default.url(for: .libraryDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
-        let filePath = url.appendingPathComponent("syncJobStore")
+        let filePath = url.appendingPathComponent("\(instanceId)-syncJobStore")
         try? FileManager.default.removeItem(atPath:  filePath.relativePath)
         
         InstanceDeviceStateStore(instanceId).clear()

--- a/Tests/Persistence/ServerSyncJobStoreTests.swift
+++ b/Tests/Persistence/ServerSyncJobStoreTests.swift
@@ -14,7 +14,7 @@ class ServerSyncJobStoreTests : XCTestCase {
     
     
     func testBasicOperations() {
-        var jobstore = ServerSyncJobStore()
+        var jobstore = ServerSyncJobStore(instanceId: TestHelper.instanceId)
 
         XCTAssertTrue(jobstore.isEmpty)
         
@@ -52,7 +52,7 @@ class ServerSyncJobStoreTests : XCTestCase {
         let contents = "[invalid_json // lol]"
         FileManager.default.createFile(atPath: filePath.relativePath, contents: contents.toData()!)
         
-        let jobstore = ServerSyncJobStore()
+        let jobstore = ServerSyncJobStore(instanceId: TestHelper.instanceId)
         
         XCTAssertTrue(jobstore.isEmpty)
         XCTAssertEqual(jobstore.toList().count, 0)
@@ -60,22 +60,22 @@ class ServerSyncJobStoreTests : XCTestCase {
     
     func testCorruptedEventShouldNotDropAllRequests() {
         let url = try! FileManager.default.url(for: .libraryDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
-        let filePath = url.appendingPathComponent("syncJobStore")
+        let filePath = url.appendingPathComponent("\(TestHelper.instanceId)-syncJobStore")
         let contents = "[{\"userIdKey\":\"danielle\",\"discriminator\":6},{\"discriminator\":7000}]"
         FileManager.default.createFile(atPath: filePath.relativePath, contents: contents.data(using: .utf8)!)
         
-        let jobstore = ServerSyncJobStore()
+        let jobstore = ServerSyncJobStore(instanceId: TestHelper.instanceId)
         XCTAssertFalse(jobstore.isEmpty)
         XCTAssertEqual(jobstore.toList().count, 1)
     }
     
     func testReportMissingInstanceIdEventShouldNotDropAllRequests() {
           let url = try! FileManager.default.url(for: .libraryDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
-          let filePath = url.appendingPathComponent("syncJobStore")
+          let filePath = url.appendingPathComponent("\(TestHelper.instanceId)-syncJobStore")
           let contents = "[{\"userIdKey\":\"danielle\",\"discriminator\":6},{\"openEventTypeKey\":{\"deviceId\":\"192031231\",\"timestampSecs\":12,\"event\":\"Open\",\"publishId\":\"13u190231\"},\"discriminator\":7}]"
           FileManager.default.createFile(atPath: filePath.relativePath, contents: contents.data(using: .utf8)!)
           
-          let jobstore = ServerSyncJobStore()
+          let jobstore = ServerSyncJobStore(instanceId: TestHelper.instanceId)
           XCTAssertFalse(jobstore.isEmpty)
           XCTAssertEqual(jobstore.toList().count, 1)
       }


### PR DESCRIPTION
### What?
We scoped the job store by instance id
...

#### Why?
this is important for multiple instances who have jobs to not clash
...

----
CC @pusher/mobile
