### PR TITLE
Allow register for remote notifications to be called from the static push notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/push-notifications-swift/compare/3.0.0...HEAD)
 
+## Fixed
+
+- Allow register for remote notifications to be called from the static push notifications.
+
+
 ## [3.0.0](https://github.com/pusher/push-notifications-swift/compare/2.1.2...3.0.0)
 
 ## Added

--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -29,7 +29,7 @@ import Foundation
     
     //! Returns a shared singleton PushNotifications object.
     /// - Tag: shared
-    @objc public static let shared = PushNotificationStatic.self
+    @objc public static let shared = PushNotificationsStatic.self
     
     private lazy var serverSyncHandler = ServerSyncProcessHandler.obtain(
         instanceId: self.instanceId,
@@ -73,7 +73,7 @@ import Foundation
      */
     /// - Tag: register
     @objc public func registerForRemoteNotifications() {
-        PushNotificationStatic.registerForRemoteNotifications()
+        PushNotificationsStatic.registerForRemoteNotifications()
     }
     #if os(iOS)
     /**
@@ -83,7 +83,7 @@ import Foundation
      */
     /// - Tag: registerOptions
     @objc public func registerForRemoteNotifications(options: UNAuthorizationOptions) {
-        PushNotificationStatic.registerForRemoteNotifications(options: options)
+        PushNotificationsStatic.registerForRemoteNotifications(options: options)
     }
     #elseif os(OSX)
     /**
@@ -92,7 +92,7 @@ import Foundation
      - Parameter options: A bit mask specifying the types of notifications the app accepts. See [NSApplication.RemoteNotificationType](https://developer.apple.com/documentation/appkit/nsapplication.remotenotificationtype) for valid bit-mask values.
      */
     @objc public func registerForRemoteNotifications(options: NSApplication.RemoteNotificationType) {
-        PushNotificationStatic.registerForRemoteNotifications(options: options)
+        PushNotificationsStatic.registerForRemoteNotifications(options: options)
     }
     #endif
 
@@ -212,7 +212,7 @@ import Foundation
      */
     /// - Tag: registerDeviceToken
     @objc public func registerDeviceToken(_ deviceToken: Data) {
-        PushNotificationStatic.registerDeviceToken(deviceToken)
+        PushNotificationsStatic.registerDeviceToken(deviceToken)
     }
 
     /**
@@ -327,7 +327,7 @@ import Foundation
     /// - Tag: handleNotification
     @discardableResult
     @objc public func handleNotification(userInfo: [AnyHashable: Any]) -> RemoteNotificationType {
-        return PushNotificationStatic.handleNotification(userInfo: userInfo)
+        return PushNotificationsStatic.handleNotification(userInfo: userInfo)
     }
 
     private func validateInterestName(_ interest: String) -> Bool {

--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -73,7 +73,7 @@ import Foundation
      */
     /// - Tag: register
     @objc public func registerForRemoteNotifications() {
-        self.registerForPushNotifications(options: [.alert, .sound, .badge])
+        PushNotificationStatic.registerForRemoteNotifications()
     }
     #if os(iOS)
     /**
@@ -83,7 +83,7 @@ import Foundation
      */
     /// - Tag: registerOptions
     @objc public func registerForRemoteNotifications(options: UNAuthorizationOptions) {
-        self.registerForPushNotifications(options: options)
+        PushNotificationStatic.registerForRemoteNotifications(options: options)
     }
     #elseif os(OSX)
     /**
@@ -92,7 +92,7 @@ import Foundation
      - Parameter options: A bit mask specifying the types of notifications the app accepts. See [NSApplication.RemoteNotificationType](https://developer.apple.com/documentation/appkit/nsapplication.remotenotificationtype) for valid bit-mask values.
      */
     @objc public func registerForRemoteNotifications(options: NSApplication.RemoteNotificationType) {
-        self.registerForPushNotifications(options: options)
+        PushNotificationStatic.registerForRemoteNotifications(options: options)
     }
     #endif
 
@@ -339,25 +339,6 @@ import Foundation
     private func validateInterestNames(_ interests: [String]) -> [String]? {
         return interests.filter { !self.validateInterestName($0) }
     }
-
-    #if os(iOS)
-    private func registerForPushNotifications(options: UNAuthorizationOptions) {
-        UNUserNotificationCenter.current().requestAuthorization(options: options) { (granted, error) in
-            if granted {
-                DispatchQueue.main.async {
-                    UIApplication.shared.registerForRemoteNotifications()
-                }
-            }
-            if let error = error {
-                print("[PushNotifications] - \(error.localizedDescription)")
-            }
-        }
-    }
-    #elseif os(OSX)
-    private func registerForPushNotifications(options: NSApplication.RemoteNotificationType) {
-        NSApplication.shared.registerForRemoteNotifications(matching: options)
-    }
-    #endif
 }
 
 /**

--- a/Sources/PushNotificationsStatic.swift
+++ b/Sources/PushNotificationsStatic.swift
@@ -7,7 +7,7 @@ import NotificationCenter
 #endif
 import Foundation
 
-@objc public final class PushNotificationStatic: NSObject {
+@objc public final class PushNotificationsStatic: NSObject {
     
     private override init() {
         // prevent other people initialising us

--- a/Sources/PushNotificationsStatic.swift
+++ b/Sources/PushNotificationsStatic.swift
@@ -47,11 +47,7 @@ import Foundation
      */
     /// - Tag: register
     @objc public static func registerForRemoteNotifications() {
-        if let staticInstance = instance {
-            staticInstance.registerForRemoteNotifications()
-        } else {
-            fatalError("PushNotifications.shared.start must have been called first")
-        }
+        self.registerForPushNotifications(options: [.alert, .sound, .badge])
     }
     
     #if os(iOS)
@@ -62,11 +58,7 @@ import Foundation
      */
     /// - Tag: registerOptions
     @objc public static func registerForRemoteNotifications(options: UNAuthorizationOptions) {
-        if let staticInstance = instance {
-            staticInstance.registerForRemoteNotifications(options: options)
-        } else {
-            fatalError("PushNotifications.shared.start must have been called first")
-        }
+        self.registerForPushNotifications(options: options)
     }
     #elseif os(OSX)
     /**
@@ -75,11 +67,26 @@ import Foundation
      - Parameter options: A bit mask specifying the types of notifications the app accepts. See [NSApplication.RemoteNotificationType](https://developer.apple.com/documentation/appkit/nsapplication.remotenotificationtype) for valid bit-mask values.
      */
     @objc public static func registerForRemoteNotifications(options: NSApplication.RemoteNotificationType) {
-        if let staticInstance = instance {
-            staticInstance.registerForRemoteNotifications(options: options)
-        } else {
-            fatalError("PushNotifications.shared.start must have been called first")
+        self.registerForPushNotifications(options: options)
+    }
+    #endif
+    
+    #if os(iOS)
+    private static func registerForPushNotifications(options: UNAuthorizationOptions) {
+        UNUserNotificationCenter.current().requestAuthorization(options: options) { (granted, error) in
+            if granted {
+                DispatchQueue.main.async {
+                    UIApplication.shared.registerForRemoteNotifications()
+                }
+            }
+            if let error = error {
+                print("[PushNotifications] - \(error.localizedDescription)")
+            }
         }
+    }
+    #elseif os(OSX)
+    private static func registerForPushNotifications(options: NSApplication.RemoteNotificationType) {
+        NSApplication.shared.registerForRemoteNotifications(matching: options)
     }
     #endif
     


### PR DESCRIPTION
### Why?

There's no reason to depend on the instance push notification.

----
CC @pusher/mobile
