### PR TITLE
Fix syntax issues that caused swifc compiler from Xcode 10 (swiftlang-1001) to not be able to determine the correct implicit return type of a closure.

### DIFF
--- a/Sources/Internal/ServerSyncProcessHandler.swift
+++ b/Sources/Internal/ServerSyncProcessHandler.swift
@@ -4,7 +4,7 @@ class ServerSyncProcessHandler {
     private static let serverSyncHandlersQueue = DispatchQueue(label: "com.pusher.beams.serverSyncHandlersQueue")
     private static var serverSyncHandlers = [String: ServerSyncProcessHandler]()
     internal static func obtain(instanceId: String, getTokenProvider: @escaping () -> TokenProvider?, handleServerSyncEvent: @escaping (ServerSyncEvent) -> Void) -> ServerSyncProcessHandler {
-        serverSyncHandlersQueue.sync {
+        return serverSyncHandlersQueue.sync {
             if let handler = self.serverSyncHandlers[instanceId] {
                 return handler
             } else {
@@ -16,7 +16,7 @@ class ServerSyncProcessHandler {
     }
     
     internal static func obtain(instanceId: String) -> ServerSyncProcessHandler? {
-        serverSyncHandlersQueue.sync {
+        return serverSyncHandlersQueue.sync {
             return self.serverSyncHandlers[instanceId]
         }
     }

--- a/Sources/ServerSyncEventHandler.swift
+++ b/Sources/ServerSyncEventHandler.swift
@@ -6,7 +6,7 @@ internal class ServerSyncEventHandler {
     static var serverSyncEventHandlers = [String: ServerSyncEventHandler]()
     
     static func obtain(instanceId: String) -> ServerSyncEventHandler {
-        serverSyncEventHandlersQueue.sync {
+        return serverSyncEventHandlersQueue.sync {
             if let handler = self.serverSyncEventHandlers[instanceId] {
                 return handler
             } else {

--- a/Tests/Persistence/ServerSyncJobStoreTests.swift
+++ b/Tests/Persistence/ServerSyncJobStoreTests.swift
@@ -31,8 +31,8 @@ class ServerSyncJobStoreTests : XCTestCase {
             XCTFail()
         }
         
-        let firstElement = jobstore.first
-        if case .SetUserIdJob(let userId) = firstElement {
+        if let firstElement = jobstore.first,
+            case .SetUserIdJob(let userId) = firstElement {
             XCTAssertEqual(userId, "danielle")
         } else {
             XCTFail()


### PR DESCRIPTION
### What?

A bit more explicit definition of return types for closures that are supposed to return `ServerSyncProcessHandler` and `ServerSyncEventHandler`.

#### Why?

Swift compiler in Xcode 10 is not able to determine the correct return type of closures due to the return type being defined implicitly.

----
CC @pusher/mobile
