### PR TITLE
Add support for stop and clearAllState to work in PushNotificationsStatic

### DIFF
--- a/Sources/PushNotificationsStatic.swift
+++ b/Sources/PushNotificationsStatic.swift
@@ -114,10 +114,16 @@ import Foundation
      */
     /// - Tag: stop
     @objc public static func stop(completion: @escaping () -> Void) {
-        if let staticInstance = instance {
-            staticInstance.stop(completion: completion)
-        } else {
-            fatalError("PushNotifications.shared.start must have been called first")
+        let instances = DeviceStateStore().getInstanceIds()
+        let dispatchGroup = DispatchGroup()
+
+        for instance in instances {
+            dispatchGroup.enter()
+            PushNotifications(instanceId: instance).stop(completion: dispatchGroup.leave)
+        }
+
+        dispatchGroup.notify(queue: .main) {
+            completion()
         }
     }
     

--- a/Sources/PushNotificationsStatic.swift
+++ b/Sources/PushNotificationsStatic.swift
@@ -131,15 +131,16 @@ import Foundation
     /// - Tag: clearAllState
     @objc public static func clearAllState(completion: @escaping () -> Void) {
         let instances = DeviceStateStore().getInstanceIds()
-        let dgroup = DispatchGroup()
+        let dispatchGroup = DispatchGroup()
 
         for instance in instances {
-            dgroup.enter()
-            PushNotifications(instanceId: instance).clearAllState(completion: dgroup.leave)
+            dispatchGroup.enter()
+            PushNotifications(instanceId: instance).clearAllState(completion: dispatchGroup.leave)
         }
 
-        dgroup.wait()
-        completion()
+        dispatchGroup.notify(queue: .main) {
+            completion()
+        }
     }
     
     /**

--- a/Sources/PushNotificationsStatic.swift
+++ b/Sources/PushNotificationsStatic.swift
@@ -130,11 +130,16 @@ import Foundation
      */
     /// - Tag: clearAllState
     @objc public static func clearAllState(completion: @escaping () -> Void) {
-        if let staticInstance = instance {
-            staticInstance.clearAllState(completion: completion)
-        } else {
-            fatalError("PushNotifications.shared.start must have been called first")
+        let instances = DeviceStateStore().getInstanceIds()
+        let dgroup = DispatchGroup()
+
+        for instance in instances {
+            dgroup.enter()
+            PushNotifications(instanceId: instance).clearAllState(completion: dgroup.leave)
         }
+
+        dgroup.wait()
+        completion()
     }
     
     /**

--- a/Tests/IntegrationTests/MultipleInstanceSupportTest.swift
+++ b/Tests/IntegrationTests/MultipleInstanceSupportTest.swift
@@ -130,6 +130,45 @@ class MultipleInstanceSupportTest: XCTestCase {
         expect(InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
     }
     
+    func testCallingClearAllStateShouldNotCrashIfNoInstancesExist() {
+        let exp = expectation(description: "clearAllState completion handler should succeed")
+
+        PushNotificationsStatic.clearAllState {
+            exp.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1)
+    }
+    
+    func testCallingClearAllStateShouldClearAllInstancesState() {
+        let pni1 = PushNotifications(instanceId: TestHelper.instanceId)
+        let pni2 = PushNotifications(instanceId: TestHelper.instanceId2)
+        
+        pni1.start()
+        pni2.start()
+        
+        pni1.registerDeviceToken(validAPNsToken)
+        
+        expect(InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        
+        let device1 = InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()!
+        let device2 = InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()!
+
+        let exp = expectation(description: "clearAllState completion handler should succeed")
+        PushNotificationsStatic.clearAllState {
+            exp.fulfill()
+        }
+        
+        waitForExpectations(timeout: 10)
+        
+        // the server shouldn't have these devices anymore
+        expect(TestAPIClientHelper().getDevice(instanceId: TestHelper.instanceId, deviceId: device1))
+            .toEventually(beNil(), timeout: 10)
+        expect(TestAPIClientHelper().getDevice(instanceId: TestHelper.instanceId2, deviceId: device2))
+            .toEventually(beNil(), timeout: 10)
+    }
+    
     class StubTokenProvider: TokenProvider {
         private let jwt: String
         private let error: Error?

--- a/Tests/IntegrationTests/MultipleInstanceSupportTest.swift
+++ b/Tests/IntegrationTests/MultipleInstanceSupportTest.swift
@@ -169,6 +169,45 @@ class MultipleInstanceSupportTest: XCTestCase {
             .toEventually(beNil(), timeout: 10)
     }
     
+    func testCallingStopShouldNotCrashIfNoInstancesExist() {
+        let exp = expectation(description: "stop completion handler should succeed")
+
+        PushNotificationsStatic.stop {
+            exp.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1)
+    }
+    
+    func testCallingStopShouldClearAllInstancesState() {
+        let pni1 = PushNotifications(instanceId: TestHelper.instanceId)
+        let pni2 = PushNotifications(instanceId: TestHelper.instanceId2)
+        
+        pni1.start()
+        pni2.start()
+        
+        pni1.registerDeviceToken(validAPNsToken)
+        
+        expect(InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        
+        let device1 = InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()!
+        let device2 = InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()!
+
+        let exp = expectation(description: "stop completion handler should succeed")
+        PushNotificationsStatic.stop {
+            exp.fulfill()
+        }
+        
+        waitForExpectations(timeout: 10)
+        
+        // the server shouldn't have these devices anymore
+        expect(TestAPIClientHelper().getDevice(instanceId: TestHelper.instanceId, deviceId: device1))
+            .toEventually(beNil(), timeout: 10)
+        expect(TestAPIClientHelper().getDevice(instanceId: TestHelper.instanceId2, deviceId: device2))
+            .toEventually(beNil(), timeout: 10)
+    }
+    
     class StubTokenProvider: TokenProvider {
         private let jwt: String
         private let error: Error?


### PR DESCRIPTION
#### Why?

Customers should be able to clear the state even from a cleared state.

----
CC @pusher/mobile
