### PR TITLE
Update OHTTPStubs and Nimble dependencies to their latest versions

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "AliSoftware/OHHTTPStubs" "9.0.0"
-github "Quick/Nimble" "v8.1.2"
+github "AliSoftware/OHHTTPStubs" "9.1.0"
+github "Quick/Nimble" "v9.0.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,12 +2,30 @@
   "object": {
     "pins": [
       {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "f809deb30dc5c9d9b78c872e553261a61177721a",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "02b7a39a99c4da27abe03cab2053a9034379639f",
+          "version": "2.0.0"
+        }
+      },
+      {
         "package": "Nimble",
         "repositoryURL": "https://github.com/Quick/Nimble",
         "state": {
           "branch": null,
-          "revision": "7a46a5fc86cb917f69e3daf79fcb045283d8f008",
-          "version": "8.1.2"
+          "revision": "e491a6731307bb23783bf664d003be9b2fa59ab5",
+          "version": "9.0.0"
         }
       },
       {
@@ -15,8 +33,8 @@
         "repositoryURL": "https://github.com/AliSoftware/OHHTTPStubs",
         "state": {
           "branch": null,
-          "revision": "e92b5a5746ef16add2a1424f1fc19529d9a75cde",
-          "version": "9.0.0"
+          "revision": "12f19662426d0434d6c330c6974d53e2eb10ecd9",
+          "version": "9.1.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -11,9 +11,9 @@ let package = Package(name: "PushNotifications",
                       ],
                       dependencies: [
                         .package(url: "https://github.com/Quick/Nimble",
-                                 .upToNextMajor(from: "8.1.2")),
-                        .package(url: "https://github.com/AliSoftware/OHHTTPStubs",
                                  .upToNextMajor(from: "9.0.0")),
+                        .package(url: "https://github.com/AliSoftware/OHHTTPStubs",
+                                 .upToNextMajor(from: "9.1.0")),
                       ],
                       targets: [
                         .target(name: "PushNotifications",

--- a/Tests/IntegrationTests/ApplicationStartTests.swift
+++ b/Tests/IntegrationTests/ApplicationStartTests.swift
@@ -24,17 +24,17 @@ class ApplicationStartTests: XCTestCase {
         pushNotifications.registerDeviceToken(validToken)
 
         let deviceStateStore = InstanceDeviceStateStore(self.instanceId)
-        expect(deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
         let deviceId = deviceStateStore.getDeviceId()!
 
         expect(TestAPIClientHelper().getDeviceInterests(instanceId: self.instanceId, deviceId: deviceId))
-            .toEventually(equal([]), timeout: 10)
+            .toEventually(equal([]), timeout: .seconds(10))
 
         _ = InstanceDeviceStateStore(self.instanceId).persistInterests(["cucas", "panda", "potato"])
         pushNotifications.start()
 
         expect(TestAPIClientHelper().getDeviceInterests(instanceId: self.instanceId, deviceId: deviceId))
-            .toEventually(contain("cucas", "panda", "potato"), timeout: 10)
+            .toEventually(contain("cucas", "panda", "potato"), timeout: .seconds(10))
     }
 }
 

--- a/Tests/IntegrationTests/ClearAllStateTest.swift
+++ b/Tests/IntegrationTests/ClearAllStateTest.swift
@@ -23,7 +23,7 @@ class ClearAllStateTest: XCTestCase {
         pushNotifications.registerDeviceToken(validToken)
 
         let deviceStateStore = InstanceDeviceStateStore(self.instanceId)
-        expect(deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
         let deviceId = deviceStateStore.getDeviceId()
 
         XCTAssertNoThrow(try pushNotifications.addDeviceInterest(interest: "a"))
@@ -34,10 +34,10 @@ class ClearAllStateTest: XCTestCase {
         }
 
         expect(TestAPIClientHelper().getDevice(instanceId: self.instanceId, deviceId: deviceId!))
-            .toEventually(beNil(), timeout: 10)
+            .toEventually(beNil(), timeout: .seconds(10))
 
         XCTAssertEqual(pushNotifications.getDeviceInterests(), [])
-        expect(InstanceDeviceStateStore(self.instanceId).getDeviceId()).toEventuallyNot(equal(deviceId!), timeout: 10)
+        expect(InstanceDeviceStateStore(self.instanceId).getDeviceId()).toEventuallyNot(equal(deviceId!), timeout: .seconds(10))
 
         waitForExpectations(timeout: 1)
     }

--- a/Tests/IntegrationTests/DeviceInterestsTest.swift
+++ b/Tests/IntegrationTests/DeviceInterestsTest.swift
@@ -69,11 +69,11 @@ class DeviceInterestsTest: XCTestCase {
         pushNotifications.start()
         pushNotifications.registerDeviceToken(validToken)
 
-        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
         let deviceId = self.deviceStateStore.getDeviceId()!
 
         expect(TestAPIClientHelper().getDeviceInterests(instanceId: self.instanceId, deviceId: deviceId))
-            .toEventually(equal(["panda"]), timeout: 10)
+            .toEventually(equal(["panda"]), timeout: .seconds(10))
     }
 
     func testLocalInterestsSetShouldBeMergedAfterDeviceRegistration() {
@@ -97,11 +97,11 @@ class DeviceInterestsTest: XCTestCase {
         pushNotifications.start()
         pushNotifications.registerDeviceToken(validToken)
 
-        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
         let deviceId = self.deviceStateStore.getDeviceId()!
 
         expect(TestAPIClientHelper().getDeviceInterests(instanceId: self.instanceId, deviceId: deviceId))
-            .toEventually(equal(["panda", "zebra"]), timeout: 10)
+            .toEventually(equal(["panda", "zebra"]), timeout: .seconds(10))
 
         // Clearing local storage to pretend that SDK didn't start.
         UserDefaults(suiteName: PersistenceConstants.UserDefaults.suiteName(instanceId: self.instanceId)).map { userDefaults in
@@ -137,12 +137,12 @@ class DeviceInterestsTest: XCTestCase {
         pushNotifications2.registerDeviceToken(validToken)
         waitForExpectations(timeout: 10)
 
-        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
         let deviceId2 = self.deviceStateStore.getDeviceId()!
         XCTAssertEqual(deviceId, deviceId2)
 
         expect(TestAPIClientHelper().getDeviceInterests(instanceId: self.instanceId, deviceId: deviceId2))
-            .toEventually(contain("zebra", "lion"), timeout: 10)
+            .toEventually(contain("zebra", "lion"), timeout: .seconds(10))
     }
 
     func testInterestsSetDidChangeAndCallbackIsCalled() {

--- a/Tests/IntegrationTests/DeviceRegistrationTests.swift
+++ b/Tests/IntegrationTests/DeviceRegistrationTests.swift
@@ -23,6 +23,6 @@ class DeviceRegistrationTests: XCTestCase {
 
         pushNotifications.registerDeviceToken(validToken)
 
-        expect(InstanceDeviceStateStore(self.instanceId).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(InstanceDeviceStateStore(self.instanceId).getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
     }
 }

--- a/Tests/IntegrationTests/MultipleClassInstanceSupportTest.swift
+++ b/Tests/IntegrationTests/MultipleClassInstanceSupportTest.swift
@@ -24,7 +24,7 @@ class MultipleClassInstanceSupportTest: XCTestCase {
         pushNotifications1.start()
         pushNotifications1.registerDeviceToken(validToken)
         
-        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
         let deviceId = self.deviceStateStore.getDeviceId()!
         
         let exp = expectation(description: "Stop completion handler must be called")
@@ -33,7 +33,7 @@ class MultipleClassInstanceSupportTest: XCTestCase {
         }
         
         expect(TestAPIClientHelper().getDevice(instanceId: TestHelper.instanceId, deviceId: deviceId))
-            .toEventually(beNil(), timeout: 10)
+            .toEventually(beNil(), timeout: .seconds(10))
         
         waitForExpectations(timeout: 1)
     }
@@ -89,12 +89,12 @@ class MultipleClassInstanceSupportTest: XCTestCase {
         pushNotifications1.start()
         pushNotifications1.registerDeviceToken(validToken)
 
-        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
         let deviceId = self.deviceStateStore.getDeviceId()!
         
         pushNotifications2.clearAllState { }
         
-        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(be(deviceId), timeout: 10)
+        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(be(deviceId), timeout: .seconds(10))
     }
     
     class StubTokenProvider: TokenProvider {

--- a/Tests/IntegrationTests/MultipleInstanceSupportTest.swift
+++ b/Tests/IntegrationTests/MultipleInstanceSupportTest.swift
@@ -51,9 +51,9 @@ class MultipleInstanceSupportTest: XCTestCase {
         let deviceId2 = InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()!
 
         expect(TestAPIClientHelper().getDevice(instanceId: TestHelper.instanceId, deviceId: deviceId1)?.userId)
-            .toEventually(equal("cucas"), timeout: 30)
+            .toEventually(equal("cucas"), timeout: .seconds(30))
         expect(TestAPIClientHelper().getDevice(instanceId: TestHelper.instanceId2, deviceId: deviceId2)?.userId)
-        .toEventually(equal("jess"), timeout: 30)
+        .toEventually(equal("jess"), timeout: .seconds(30))
     }
     
     func testStoppingOneShouldNotStopTheOther() {
@@ -66,13 +66,13 @@ class MultipleInstanceSupportTest: XCTestCase {
         pni1.registerDeviceToken(validAPNsToken)
         pni2.registerDeviceToken(validAPNsToken)
         
-        expect(InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
-        expect(InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
+        expect(InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
         
         pni1.stop { }
         
-        expect(InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()).toEventually(beNil(), timeout: 10)
-        expect(InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()).toEventually(beNil(), timeout: .seconds(10))
+        expect(InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
     }
     
     func testInterestsShouldNotAffectEachOther() {
@@ -85,8 +85,8 @@ class MultipleInstanceSupportTest: XCTestCase {
         pni1.registerDeviceToken(validAPNsToken)
         pni2.registerDeviceToken(validAPNsToken)
         
-        expect(InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
-        expect(InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
+        expect(InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
         
         let device1 = InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()!
         let device2 = InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()!
@@ -98,9 +98,9 @@ class MultipleInstanceSupportTest: XCTestCase {
         XCTAssertTrue(pni2.getDeviceInterests()!.containsSameElements(as: ["pizza", "burger", "chip"]))
         
         expect(TestAPIClientHelper().getDeviceInterests(instanceId: TestHelper.instanceId, deviceId: device1))
-            .toEventually(contain("carrot", "sweetcorn", "pea"), timeout: 10)
+            .toEventually(contain("carrot", "sweetcorn", "pea"), timeout: .seconds(10))
         expect(TestAPIClientHelper().getDeviceInterests(instanceId: TestHelper.instanceId2, deviceId: device2))
-            .toEventually(contain("pizza", "burger", "chip"), timeout: 10)
+            .toEventually(contain("pizza", "burger", "chip"), timeout: .seconds(10))
         
         try! pni1.addDeviceInterest(interest: "okra")
         try! pni1.removeDeviceInterest(interest: "sweetcorn")
@@ -111,9 +111,9 @@ class MultipleInstanceSupportTest: XCTestCase {
         XCTAssertTrue(pni2.getDeviceInterests()!.containsSameElements(as: ["pizza", "hotdog", "chip"]))
         
         expect(TestAPIClientHelper().getDeviceInterests(instanceId: TestHelper.instanceId, deviceId: device1))
-            .toEventually(contain("carrot", "okra", "pea"), timeout: 10)
+            .toEventually(contain("carrot", "okra", "pea"), timeout: .seconds(10))
         expect(TestAPIClientHelper().getDeviceInterests(instanceId: TestHelper.instanceId2, deviceId: device2))
-            .toEventually(contain("pizza", "hotdog", "chip"), timeout: 10)
+            .toEventually(contain("pizza", "hotdog", "chip"), timeout: .seconds(10))
         
     }
     
@@ -126,8 +126,8 @@ class MultipleInstanceSupportTest: XCTestCase {
         
         pni1.registerDeviceToken(validAPNsToken)
         
-        expect(InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
-        expect(InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
+        expect(InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
     }
     
     func testCallingClearAllStateShouldNotCrashIfNoInstancesExist() {
@@ -149,8 +149,8 @@ class MultipleInstanceSupportTest: XCTestCase {
         
         pni1.registerDeviceToken(validAPNsToken)
         
-        expect(InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
-        expect(InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
+        expect(InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
         
         let device1 = InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()!
         let device2 = InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()!
@@ -164,9 +164,9 @@ class MultipleInstanceSupportTest: XCTestCase {
         
         // the server shouldn't have these devices anymore
         expect(TestAPIClientHelper().getDevice(instanceId: TestHelper.instanceId, deviceId: device1))
-            .toEventually(beNil(), timeout: 10)
+            .toEventually(beNil(), timeout: .seconds(10))
         expect(TestAPIClientHelper().getDevice(instanceId: TestHelper.instanceId2, deviceId: device2))
-            .toEventually(beNil(), timeout: 10)
+            .toEventually(beNil(), timeout: .seconds(10))
     }
     
     func testCallingStopShouldNotCrashIfNoInstancesExist() {
@@ -188,8 +188,8 @@ class MultipleInstanceSupportTest: XCTestCase {
         
         pni1.registerDeviceToken(validAPNsToken)
         
-        expect(InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
-        expect(InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
+        expect(InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
         
         let device1 = InstanceDeviceStateStore(TestHelper.instanceId).getDeviceId()!
         let device2 = InstanceDeviceStateStore(TestHelper.instanceId2).getDeviceId()!
@@ -203,9 +203,9 @@ class MultipleInstanceSupportTest: XCTestCase {
         
         // the server shouldn't have these devices anymore
         expect(TestAPIClientHelper().getDevice(instanceId: TestHelper.instanceId, deviceId: device1))
-            .toEventually(beNil(), timeout: 10)
+            .toEventually(beNil(), timeout: .seconds(10))
         expect(TestAPIClientHelper().getDevice(instanceId: TestHelper.instanceId2, deviceId: device2))
-            .toEventually(beNil(), timeout: 10)
+            .toEventually(beNil(), timeout: .seconds(10))
     }
     
     class StubTokenProvider: TokenProvider {

--- a/Tests/IntegrationTests/ReportEventTypeTests.swift
+++ b/Tests/IntegrationTests/ReportEventTypeTests.swift
@@ -23,7 +23,7 @@ class ReportEventTypeTests: XCTestCase {
 
         pushNotifications.registerDeviceToken(validToken)
 
-        expect(InstanceDeviceStateStore(self.instanceId).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(InstanceDeviceStateStore(self.instanceId).getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
 
         let userInfo = ["aps": ["alert": ["title": "Hello", "body": "Hello, world!"], "content-available": 1], "data": ["pusher": ["publishId": "pubid-33f3f68e-b0c5-438f-b50f-fae93f6c48df"]]]
 

--- a/Tests/IntegrationTests/SetUserIdTest.swift
+++ b/Tests/IntegrationTests/SetUserIdTest.swift
@@ -23,14 +23,14 @@ class SetUserIdTest: XCTestCase {
         pushNotifications.start()
         pushNotifications.registerDeviceToken(validToken)
 
-        expect(InstanceDeviceStateStore(self.instanceId).getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(InstanceDeviceStateStore(self.instanceId).getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
         let deviceId = InstanceDeviceStateStore(self.instanceId).getDeviceId()!
 
         let tokenProvider = StubTokenProvider(jwt: validCucasJWTToken, error: nil)
         pushNotifications.setUserId("cucas", tokenProvider: tokenProvider) { _ in }
 
         expect(TestAPIClientHelper().getDevice(instanceId: self.instanceId, deviceId: deviceId)?.userId)
-            .toEventually(equal("cucas"), timeout: 30)
+            .toEventually(equal("cucas"), timeout: .seconds(30))
     }
 
     func testSetUserIdShouldThrowExceptionIfUserIdIsReassigned() {

--- a/Tests/IntegrationTests/StopTests.swift
+++ b/Tests/IntegrationTests/StopTests.swift
@@ -23,7 +23,7 @@ class StopTests: XCTestCase {
         pushNotifications.start()
         pushNotifications.registerDeviceToken(validToken)
 
-        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
         let deviceId = self.deviceStateStore.getDeviceId()!
 
         let exp = expectation(description: "Stop completion handler must be called")
@@ -32,7 +32,7 @@ class StopTests: XCTestCase {
         }
 
         expect(TestAPIClientHelper().getDevice(instanceId: self.instanceId, deviceId: deviceId))
-            .toEventually(beNil(), timeout: 10)
+            .toEventually(beNil(), timeout: .seconds(10))
 
         waitForExpectations(timeout: 1)
     }
@@ -42,7 +42,7 @@ class StopTests: XCTestCase {
         pushNotifications.start()
         pushNotifications.registerDeviceToken(validToken)
 
-        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
 
         pushNotifications.stop { }
 
@@ -54,15 +54,15 @@ class StopTests: XCTestCase {
         pushNotifications.start()
         pushNotifications.registerDeviceToken(validToken)
 
-        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
 
         pushNotifications.stop { }
 
-        expect(self.deviceStateStore.getDeviceId()).toEventually(beNil(), timeout: 10)
+        expect(self.deviceStateStore.getDeviceId()).toEventually(beNil(), timeout: .seconds(10))
 
         pushNotifications.start()
         pushNotifications.registerDeviceToken(validToken)
 
-        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: 10)
+        expect(self.deviceStateStore.getDeviceId()).toEventuallyNot(beNil(), timeout: .seconds(10))
     }
 }


### PR DESCRIPTION
This PR:

- Updates [OHTTPStubs](https://github.com/AliSoftware/OHHTTPStubs) and [Nimble](https://github.com/Quick/Nimble) to their latest available versions
  - Also refactors the Nimble API usage where necessary (for breaking changes).