### PR TITLE
Use the Swift 5 'Result' type from the Standard Library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,4 +25,4 @@ let package = Package(name: "PushNotifications",
                                                    "OHHTTPStubsSwift"],
                                     path: "Tests")
                       ],
-                      swiftLanguageVersions: [.v4, .v4_2, .v5])
+                      swiftLanguageVersions: [.v5])

--- a/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
+++ b/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
@@ -46,7 +46,6 @@
 		A144AB4F1F9E3DA3009F0040 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = A144AB471F9E3DA2009F0040 /* Device.swift */; };
 		A144AB501F9E3DA3009F0040 /* PushNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = A144AB481F9E3DA2009F0040 /* PushNotifications.swift */; };
 		A144AB511F9E3DA3009F0040 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A144AB491F9E3DA3009F0040 /* HTTPMethod.swift */; };
-		A1482A582181F3CD00F19A4E /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1482A572181F3CD00F19A4E /* Result.swift */; };
 		A1504E17206B9D98002D1E74 /* EventTypeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1504E16206B9D98002D1E74 /* EventTypeHandler.swift */; };
 		A155BFBD1F9E38040070A609 /* PushNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A155BFB31F9E38040070A609 /* PushNotifications.framework */; };
 		A155BFC41F9E38040070A609 /* PushNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = A155BFB61F9E38040070A609 /* PushNotifications.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -138,7 +137,6 @@
 		A144AB471F9E3DA2009F0040 /* Device.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
 		A144AB481F9E3DA2009F0040 /* PushNotifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushNotifications.swift; path = ../../Sources/PushNotifications.swift; sourceTree = "<group>"; };
 		A144AB491F9E3DA3009F0040 /* HTTPMethod.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HTTPMethod.swift; path = ../../Sources/HTTPMethod.swift; sourceTree = "<group>"; };
-		A1482A572181F3CD00F19A4E /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Result.swift; path = ../../Sources/Result.swift; sourceTree = "<group>"; };
 		A1504E16206B9D98002D1E74 /* EventTypeHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EventTypeHandler.swift; path = ../../Sources/EventTypeHandler.swift; sourceTree = "<group>"; };
 		A155BFB31F9E38040070A609 /* PushNotifications.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PushNotifications.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A155BFB61F9E38040070A609 /* PushNotifications.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PushNotifications.h; sourceTree = "<group>"; };
@@ -302,7 +300,6 @@
 				A1E78E302020AEF400DD94B2 /* Register.swift */,
 				A1EFF5C8207B7E78006C3004 /* RemoteNotificationType.swift */,
 				A1E80009201A213000467EB9 /* ReportEventType.swift */,
-				A1482A572181F3CD00F19A4E /* Result.swift */,
 				A140FFD62020C5E600931AF6 /* SDK.swift */,
 				A1DAD62D2020CAE7001497B5 /* SystemVersion.swift */,
 				A19B15D22189E4FC008E6DB5 /* Token.swift */,
@@ -544,7 +541,6 @@
 				A1F0E942219B18B800D32363 /* PushNotificationsError.swift in Sources */,
 				A1327BE02178EB62001483E1 /* AuthData.swift in Sources */,
 				A126312722CB726900DDAD28 /* ServerSyncJob.swift in Sources */,
-				A1482A582181F3CD00F19A4E /* Result.swift in Sources */,
 				A1D2AC3D22560D3E00AF4871 /* String+HexStringToData.swift in Sources */,
 				A1F122E42237C90600F7D766 /* NetworkService.swift in Sources */,
 				A1DAD62E2020CAE7001497B5 /* SystemVersion.swift in Sources */,

--- a/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
+++ b/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
@@ -767,7 +767,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -794,7 +794,7 @@
 				SDKROOT = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -832,7 +832,7 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				SWIFT_OBJC_BRIDGING_HEADER = "PushNotificationsTests/PushNotificationsTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -869,7 +869,7 @@
 				SDKROOT = "";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				SWIFT_OBJC_BRIDGING_HEADER = "PushNotificationsTests/PushNotificationsTests-Bridging-Header.h";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ### Minimum Requirements
 
-- [Swift 4.0+](https://github.com/pusher/push-notifications-swift/commit/d6dfa2186195135d8d7d1e3d3efdd7f8661ea404)
+- Swift 5.0+
 - [Xcode](https://itunes.apple.com/us/app/xcode/id497799835) - The easiest way to get Xcode is from the [App Store](https://itunes.apple.com/us/app/xcode/id497799835?mt=12), but you can also download it from [developer.apple.com](https://developer.apple.com/) if you have an AppleID registered with an Apple Developer account.
 
 ## Installation

--- a/Sources/API/NetworkService.swift
+++ b/Sources/API/NetworkService.swift
@@ -13,23 +13,23 @@ class NetworkService: PushNotificationsNetworkable {
             let bundleIdentifier = Bundle.main.bundleIdentifier ?? "missing-bundle-id"
 
             guard let body = try? Register(token: deviceToken, bundleIdentifier: bundleIdentifier, metadata: metadata).encode() else {
-                return .error(.genericError(reason: "Error while encoding register payload."))
+                return .failure(.genericError(reason: "Error while encoding register payload."))
             }
 
             guard let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns") else {
-                return .error(.genericError(reason: "Error while constructing the URL."))
+                return .failure(.genericError(reason: "Error while constructing the URL."))
             }
 
             let request = self.setRequest(url: url, httpMethod: .POST, body: body)
 
             switch self.networkRequest(request, session: self.session, retryStrategy: retryStrategy) {
-            case .value(let response):
+            case .success(let response):
                 guard let device = try? JSONDecoder().decode(Device.self, from: response) else {
-                    return .error(.genericError(reason: "Error while encoding device payload."))
+                    return .failure(.genericError(reason: "Error while encoding device payload."))
                 }
-                return .value(device)
-            case .error(let error):
-                return .error(error)
+                return .success(device)
+            case .failure(let error):
+                return .failure(error)
             }
         }
     }
@@ -37,16 +37,16 @@ class NetworkService: PushNotificationsNetworkable {
     func subscribe(instanceId: String, deviceId: String, interest: String, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
         return retryStrategy.retry {
             guard let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/interests/\(interest)") else {
-                return .error(.genericError(reason: "Error while constructing the URL."))
+                return .failure(.genericError(reason: "Error while constructing the URL."))
             }
 
             let request = self.setRequest(url: url, httpMethod: .POST)
 
             switch self.networkRequest(request, session: self.session, retryStrategy: retryStrategy) {
-            case .value:
-                return .value(())
-            case .error(let error):
-                return .error(error)
+            case .success:
+                return .success(())
+            case .failure(let error):
+                return .failure(error)
             }
         }
     }
@@ -54,19 +54,19 @@ class NetworkService: PushNotificationsNetworkable {
     func setSubscriptions(instanceId: String, deviceId: String, interests: [String], retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
         return retryStrategy.retry {
             guard let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/interests") else {
-                return .error(.genericError(reason: "Error while constructing the URL."))
+                return .failure(.genericError(reason: "Error while constructing the URL."))
             }
 
             guard let body = try? Interests(interests: interests).encode() else {
-                return .error(.genericError(reason: "Error while encoding the interests payload."))
+                return .failure(.genericError(reason: "Error while encoding the interests payload."))
             }
             let request = self.setRequest(url: url, httpMethod: .PUT, body: body)
 
             switch self.networkRequest(request, session: self.session, retryStrategy: retryStrategy) {
-            case .value:
-                return .value(())
-            case .error(let error):
-                return .error(error)
+            case .success:
+                return .success(())
+            case .failure(let error):
+                return .failure(error)
             }
         }
     }
@@ -74,16 +74,16 @@ class NetworkService: PushNotificationsNetworkable {
     func unsubscribe(instanceId: String, deviceId: String, interest: String, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
         return retryStrategy.retry {
             guard let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/interests/\(interest)") else {
-                return .error(.genericError(reason: "Error while constructing the URL."))
+                return .failure(.genericError(reason: "Error while constructing the URL."))
             }
 
             let request = self.setRequest(url: url, httpMethod: .DELETE)
 
             switch self.networkRequest(request, session: self.session, retryStrategy: retryStrategy) {
-            case .value:
-                return .value(())
-            case .error(let error):
-                return .error(error)
+            case .success:
+                return .success(())
+            case .failure(let error):
+                return .failure(error)
             }
         }
     }
@@ -91,19 +91,19 @@ class NetworkService: PushNotificationsNetworkable {
     func track(instanceId: String, deviceId: String, eventType: ReportEventType, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
         return retryStrategy.retry {
             guard let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/reporting_api/v2/instances/\(instanceId)/events") else {
-                return .error(.genericError(reason: "Error while constructing the URL."))
+                return .failure(.genericError(reason: "Error while constructing the URL."))
             }
 
             guard let body = try? eventType.encode() else {
-                return .error(.genericError(reason: "Error while encoding the event type payload."))
+                return .failure(.genericError(reason: "Error while encoding the event type payload."))
             }
 
             let request = self.setRequest(url: url, httpMethod: .POST, body: body)
             switch self.networkRequest(request, session: self.session, retryStrategy: retryStrategy) {
-            case .value:
-                return .value(())
-            case .error(let error):
-                return .error(error)
+            case .success:
+                return .success(())
+            case .failure(let error):
+                return .failure(error)
             }
         }
     }
@@ -111,18 +111,18 @@ class NetworkService: PushNotificationsNetworkable {
     func syncMetadata(instanceId: String, deviceId: String, metadata: Metadata, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
         return retryStrategy.retry {
             guard let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/metadata") else {
-                return .error(.genericError(reason: "Error while constructing the URL."))
+                return .failure(.genericError(reason: "Error while constructing the URL."))
             }
 
             guard let body = try? metadata.encode() else {
-                return .error(.genericError(reason: "Error while encoding the metadata payload."))
+                return .failure(.genericError(reason: "Error while encoding the metadata payload."))
             }
             let request = self.setRequest(url: url, httpMethod: .PUT, body: body)
             switch self.networkRequest(request, session: self.session, retryStrategy: retryStrategy) {
-            case .value:
-                return .value(())
-            case .error(let error):
-                return .error(error)
+            case .success:
+                return .success(())
+            case .failure(let error):
+                return .failure(error)
             }
         }
     }
@@ -130,16 +130,16 @@ class NetworkService: PushNotificationsNetworkable {
     func setUserId(instanceId: String, deviceId: String, token: String, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
         return retryStrategy.retry {
             guard let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/user") else {
-                return .error(.genericError(reason: "Error while constructing the URL."))
+                return .failure(.genericError(reason: "Error while constructing the URL."))
             }
 
             var request = self.setRequest(url: url, httpMethod: .PUT)
             request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
             switch self.networkRequest(request, session: self.session, retryStrategy: retryStrategy) {
-            case .value:
-                return .value(())
-            case .error(let error):
-                return .error(error)
+            case .success:
+                return .success(())
+            case .failure(let error):
+                return .failure(error)
             }
         }
     }
@@ -147,15 +147,15 @@ class NetworkService: PushNotificationsNetworkable {
     func deleteDevice(instanceId: String, deviceId: String, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
         return retryStrategy.retry {
             guard let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)") else {
-                return .error(.genericError(reason: "Error while constructing the URL."))
+                return .failure(.genericError(reason: "Error while constructing the URL."))
             }
 
             let request = self.setRequest(url: url, httpMethod: .DELETE)
             switch self.networkRequest(request, session: self.session, retryStrategy: retryStrategy) {
-            case .value:
-                return .value(())
-            case .error(let error):
-                return .error(error)
+            case .success:
+                return .success(())
+            case .failure(let error):
+                return .failure(error)
             }
         }
     }
@@ -163,15 +163,15 @@ class NetworkService: PushNotificationsNetworkable {
     func getDevice(instanceId: String, deviceId: String, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
         return retryStrategy.retry {
             guard let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)") else {
-                return .error(.genericError(reason: "Error while constructing the URL."))
+                return .failure(.genericError(reason: "Error while constructing the URL."))
             }
 
             let request = self.setRequest(url: url, httpMethod: .GET)
             switch self.networkRequest(request, session: self.session, retryStrategy: retryStrategy) {
-            case .value:
-                return .value(())
-            case .error(let error):
-                return .error(error)
+            case .success:
+                return .success(())
+            case .failure(let error):
+                return .failure(error)
             }
         }
     }
@@ -186,13 +186,13 @@ class NetworkService: PushNotificationsNetworkable {
                 let data = data,
                 let httpURLResponse = response as? HTTPURLResponse
             else {
-                result = .error(.genericError(reason: "Error!"))
+                result = .failure(.genericError(reason: "Error!"))
                 semaphore.signal()
                 return
             }
 
             if error != nil {
-                result = .error(.genericError(reason: "\(error!.localizedDescription)"))
+                result = .failure(.genericError(reason: "\(error!.localizedDescription)"))
                 semaphore.signal()
                 return
             }
@@ -200,26 +200,26 @@ class NetworkService: PushNotificationsNetworkable {
             let statusCode = httpURLResponse.statusCode
             switch statusCode {
             case 200..<300:
-                result = .value(data)
+                result = .success(data)
             case 400:
                 let reason = try? JSONDecoder().decode(Reason.self, from: data)
 
-                result = .error(.badRequest(reason: reason?.description  ?? "Unknown API error"))
+                result = .failure(.badRequest(reason: reason?.description  ?? "Unknown API error"))
             case 401, 403:
                 let reason = try? JSONDecoder().decode(Reason.self, from: data)
 
                 // Hack, until we add error codes in the server.
                 if reason?.description.contains("device token") ?? false {
-                    result = .error(.badDeviceToken(reason: reason!.description))
+                    result = .failure(.badDeviceToken(reason: reason!.description))
                 } else {
-                    result = .error(.badJWT(reason: reason?.description  ?? "Unknown API error"))
+                    result = .failure(.badJWT(reason: reason?.description  ?? "Unknown API error"))
                 }
             case 404:
-                result = .error(.deviceNotFound)
+                result = .failure(.deviceNotFound)
             default:
                 let reason = try? JSONDecoder().decode(Reason.self, from: data)
 
-                result = .error(.genericError(reason: reason?.description  ?? "Unknown API error"))
+                result = .failure(.genericError(reason: reason?.description  ?? "Unknown API error"))
             }
 
             semaphore.signal()

--- a/Sources/API/PushNotificationsAPIError.swift
+++ b/Sources/API/PushNotificationsAPIError.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-enum PushNotificationsAPIError {
+enum PushNotificationsAPIError: Error, CustomDebugStringConvertible {
     case deviceNotFound
     case badRequest(reason: String)
     case badJWT(reason: String)
     case genericError(reason: String)
     case badDeviceToken(reason: String)
 
-    func getErrorMessage() -> String {
+    var debugDescription: String {
         switch self {
         case .deviceNotFound:
             return "Device Not Found"

--- a/Sources/API/RetryStrategy.swift
+++ b/Sources/API/RetryStrategy.swift
@@ -9,10 +9,10 @@ public struct JustDont: RetryStrategy {
         let result = function()
 
         switch result {
-        case .error(let error):
-            print("[PushNotifications]: Network error: \(error.getErrorMessage())")
+        case .failure(let error):
+            print("[PushNotifications]: Network error: \(error.debugDescription)")
             return result
-        case .value:
+        case .success:
             return result
         }
     }
@@ -26,19 +26,19 @@ public class WithInfiniteExpBackoff: RetryStrategy {
             let result = function()
 
             switch result {
-            case .error(let error):
+            case .failure(let error):
                 switch error {
                 case .deviceNotFound, .badRequest, .badJWT, .badDeviceToken:
                     // Not recoverable cases.
                     return result
                 case .genericError:
-                    print("[PushNotifications]: Network error: \(error.getErrorMessage())")
+                    print("[PushNotifications]: Network error: \(error.debugDescription)")
                     self.retryCount += 1
                     let delay = calculateExponentialBackoffMs(attemptCount: self.retryCount)
                     Thread.sleep(forTimeInterval: TimeInterval(delay / 1000.0))
                     continue
                 }
-            case .value:
+            case .success:
                 return result
             }
         }

--- a/Sources/Result.swift
+++ b/Sources/Result.swift
@@ -1,6 +1,0 @@
-import Foundation
-
-public enum Result<Value, Error> {
-    case value(Value)
-    case error(Error)
-}


### PR DESCRIPTION
This PR resolves #165 :

- Replaces the custom implementation of `Result` with the Swift 5 STL implementation.
  - Increases the Swift Language Version to 5.0 in the Xcode project file and `Package.swift` accordingly.
