### PR TITLE
Refactor 'NetworkService' URLs to avoid repeated string literals

### DIFF
--- a/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
+++ b/PushNotifications/PushNotifications.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		534FE4B925B854A800093A38 /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53202DC125B0A966009221F6 /* FeatureFlags.swift */; };
 		534FE4BC25B854B000093A38 /* DeviceTokenHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53202DD025B0A966009221F6 /* DeviceTokenHelper.swift */; };
 		534FE4BF25B8551B00093A38 /* BeamsTokenProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53202DDA25B0A966009221F6 /* BeamsTokenProvider.swift */; };
+		534FE4CB25B9BDF900093A38 /* URL+NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534FE4CA25B9BDF900093A38 /* URL+NetworkService.swift */; };
 		A144AB501F9E3DA3009F0040 /* PushNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = A144AB481F9E3DA2009F0040 /* PushNotifications.swift */; };
 		A155BFBD1F9E38040070A609 /* PushNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A155BFB31F9E38040070A609 /* PushNotifications.framework */; };
 		A155BFC41F9E38040070A609 /* PushNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = A155BFB61F9E38040070A609 /* PushNotifications.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -170,6 +171,7 @@
 		53202E2F25B0A9AD009221F6 /* ApplicationStartTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationStartTests.swift; sourceTree = "<group>"; };
 		53202E3025B0A9AD009221F6 /* ClearAllStateTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClearAllStateTest.swift; sourceTree = "<group>"; };
 		53202E3125B0A9AD009221F6 /* DeviceInterestsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceInterestsTest.swift; sourceTree = "<group>"; };
+		534FE4CA25B9BDF900093A38 /* URL+NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+NetworkService.swift"; sourceTree = "<group>"; };
 		A1197BD6206266D200FD7335 /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = ../Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		A144AB481F9E3DA2009F0040 /* PushNotifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushNotifications.swift; path = ../../Sources/PushNotifications.swift; sourceTree = "<group>"; };
 		A144AB491F9E3DA3009F0040 /* HTTPMethod.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HTTPMethod.swift; path = ../../Sources/HTTPMethod.swift; sourceTree = "<group>"; };
@@ -239,6 +241,7 @@
 				53202DCC25B0A966009221F6 /* Encodable+Encode.swift */,
 				53202DCD25B0A966009221F6 /* Array+CalculateMD5Hash.swift */,
 				53202DCE25B0A966009221F6 /* String+HexStringToData.swift */,
+				534FE4CA25B9BDF900093A38 /* URL+NetworkService.swift */,
 			);
 			name = Extensions;
 			path = ../../Sources/Extensions;
@@ -588,6 +591,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A144AB501F9E3DA3009F0040 /* PushNotifications.swift in Sources */,
+				534FE4CB25B9BDF900093A38 /* URL+NetworkService.swift in Sources */,
 				53202DEB25B0A966009221F6 /* PublishId.swift in Sources */,
 				53202E0425B0A966009221F6 /* NetworkService.swift in Sources */,
 				53202DF725B0A966009221F6 /* Encodable+Encode.swift in Sources */,

--- a/Sources/Extensions/URL+NetworkService.swift
+++ b/Sources/Extensions/URL+NetworkService.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+extension URL {
+
+    struct PushNotifications {
+
+        // MARK: - Private methods
+
+        private static let hostName = "pushnotifications.pusher.com"
+
+        private static func devicesEndpoint(instanceId: String) -> String {
+            return "https://\(instanceId).\(hostName)/device_api/v1/instances/\(instanceId)/devices/apns"
+        }
+
+        private static func deviceEndpoint(instanceId: String,
+                                           deviceId: String) -> String {
+            return "\(devicesEndpoint(instanceId: instanceId))/\(deviceId)"
+        }
+
+        private static func eventEndpoint(instanceId: String) -> String {
+            return "https://\(instanceId).\(hostName)/reporting_api/v2/instances/\(instanceId)/events"
+        }
+
+        // MARK: - Endpoint URLs
+
+        static func devices(instanceId: String) -> URL? {
+            return URL(string: devicesEndpoint(instanceId: instanceId))
+        }
+
+        static func device(instanceId: String,
+                           deviceId: String) -> URL? {
+            return URL(string: deviceEndpoint(instanceId: instanceId, deviceId: deviceId))
+        }
+
+        static func interests(instanceId: String,
+                              deviceId: String) -> URL? {
+            return URL(string: "\(deviceEndpoint(instanceId: instanceId, deviceId: deviceId))/interests")
+        }
+
+        static func interest(instanceId: String,
+                             deviceId: String,
+                             interest: String) -> URL? {
+            return URL(string: "\(deviceEndpoint(instanceId: instanceId, deviceId: deviceId))/interests/\(interest)")
+        }
+
+        static func events(instanceId: String) -> URL? {
+            return URL(string: eventEndpoint(instanceId: instanceId))
+        }
+
+        static func metadata(instanceId: String,
+                             deviceId: String) -> URL? {
+            return URL(string: "\(deviceEndpoint(instanceId: instanceId, deviceId: deviceId))/metadata")
+        }
+
+        static func user(instanceId: String,
+                         deviceId: String) -> URL? {
+            return URL(string: "\(deviceEndpoint(instanceId: instanceId, deviceId: deviceId))/user")
+        }
+
+    }
+}

--- a/Sources/Protocols/PushNotificationsNetworkable.swift
+++ b/Sources/Protocols/PushNotificationsNetworkable.swift
@@ -3,21 +3,45 @@ import Foundation
 typealias CompletionHandler<T> = (_ result: T) -> Void
 
 protocol PushNotificationsNetworkable {
-    func register(instanceId: String, deviceToken: String, metadata: Metadata, retryStrategy: RetryStrategy) -> Result<Device, PushNotificationsAPIError>
+    func register(instanceId: String,
+                  deviceToken: String, metadata: Metadata,
+                  retryStrategy: RetryStrategy) -> Result<Device, PushNotificationsAPIError>
 
-    func subscribe(instanceId: String, deviceId: String, interest: String, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError>
+    func subscribe(instanceId: String,
+                   deviceId: String,
+                   interest: String,
+                   retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError>
 
-    func setSubscriptions(instanceId: String, deviceId: String, interests: [String], retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError>
+    func setSubscriptions(instanceId: String,
+                          deviceId: String,
+                          interests: [String],
+                          retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError>
 
-    func unsubscribe(instanceId: String, deviceId: String, interest: String, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError>
+    func unsubscribe(instanceId: String,
+                     deviceId: String,
+                     interest: String,
+                     retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError>
 
-    func track(instanceId: String, deviceId: String, eventType: ReportEventType, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError>
+    func track(instanceId: String,
+               deviceId: String,
+               eventType: ReportEventType,
+               retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError>
 
-    func syncMetadata(instanceId: String, deviceId: String, metadata: Metadata, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError>
+    func syncMetadata(instanceId: String,
+                      deviceId: String,
+                      metadata: Metadata,
+                      retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError>
 
-    func setUserId(instanceId: String, deviceId: String, token: String, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError>
+    func setUserId(instanceId: String,
+                   deviceId: String,
+                   token: String,
+                   retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError>
 
-    func deleteDevice(instanceId: String, deviceId: String, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError>
+    func deleteDevice(instanceId: String,
+                      deviceId: String,
+                      retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError>
 
-    func getDevice(instanceId: String, deviceId: String, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError>
+    func getDevice(instanceId: String,
+                   deviceId: String,
+                   retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError>
 }

--- a/Sources/Services/NetworkService.swift
+++ b/Sources/Services/NetworkService.swift
@@ -8,15 +8,20 @@ class NetworkService: PushNotificationsNetworkable {
     }
 
     // MARK: PushNotificationsNetworkable
-    func register(instanceId: String, deviceToken: String, metadata: Metadata, retryStrategy: RetryStrategy) -> Result<Device, PushNotificationsAPIError> {
+    func register(instanceId: String,
+                  deviceToken: String,
+                  metadata: Metadata,
+                  retryStrategy: RetryStrategy) -> Result<Device, PushNotificationsAPIError> {
         return retryStrategy.retry {
             let bundleIdentifier = Bundle.main.bundleIdentifier ?? "missing-bundle-id"
 
-            guard let body = try? Register(token: deviceToken, bundleIdentifier: bundleIdentifier, metadata: metadata).encode() else {
+            guard let body = try? Register(token: deviceToken,
+                                           bundleIdentifier: bundleIdentifier,
+                                           metadata: metadata).encode() else {
                 return .failure(.genericError(reason: "Error while encoding register payload."))
             }
 
-            guard let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns") else {
+            guard let url = URL.PushNotifications.devices(instanceId: instanceId) else {
                 return .failure(.genericError(reason: "Error while constructing the URL."))
             }
 
@@ -34,9 +39,14 @@ class NetworkService: PushNotificationsNetworkable {
         }
     }
 
-    func subscribe(instanceId: String, deviceId: String, interest: String, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
+    func subscribe(instanceId: String,
+                   deviceId: String,
+                   interest: String,
+                   retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
         return retryStrategy.retry {
-            guard let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/interests/\(interest)") else {
+            guard let url = URL.PushNotifications.interest(instanceId: instanceId,
+                                                           deviceId: deviceId,
+                                                           interest: interest) else {
                 return .failure(.genericError(reason: "Error while constructing the URL."))
             }
 
@@ -51,9 +61,13 @@ class NetworkService: PushNotificationsNetworkable {
         }
     }
 
-    func setSubscriptions(instanceId: String, deviceId: String, interests: [String], retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
+    func setSubscriptions(instanceId: String,
+                          deviceId: String,
+                          interests: [String],
+                          retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
         return retryStrategy.retry {
-            guard let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/interests") else {
+            guard let url = URL.PushNotifications.interests(instanceId: instanceId,
+                                                            deviceId: deviceId) else {
                 return .failure(.genericError(reason: "Error while constructing the URL."))
             }
 
@@ -71,9 +85,14 @@ class NetworkService: PushNotificationsNetworkable {
         }
     }
 
-    func unsubscribe(instanceId: String, deviceId: String, interest: String, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
+    func unsubscribe(instanceId: String,
+                     deviceId: String,
+                     interest: String,
+                     retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
         return retryStrategy.retry {
-            guard let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/interests/\(interest)") else {
+            guard let url = URL.PushNotifications.interest(instanceId: instanceId,
+                                                           deviceId: deviceId,
+                                                           interest: interest) else {
                 return .failure(.genericError(reason: "Error while constructing the URL."))
             }
 
@@ -88,9 +107,12 @@ class NetworkService: PushNotificationsNetworkable {
         }
     }
 
-    func track(instanceId: String, deviceId: String, eventType: ReportEventType, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
+    func track(instanceId: String,
+               deviceId: String,
+               eventType: ReportEventType,
+               retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
         return retryStrategy.retry {
-            guard let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/reporting_api/v2/instances/\(instanceId)/events") else {
+            guard let url = URL.PushNotifications.events(instanceId: instanceId) else {
                 return .failure(.genericError(reason: "Error while constructing the URL."))
             }
 
@@ -108,9 +130,13 @@ class NetworkService: PushNotificationsNetworkable {
         }
     }
 
-    func syncMetadata(instanceId: String, deviceId: String, metadata: Metadata, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
+    func syncMetadata(instanceId: String,
+                      deviceId: String,
+                      metadata: Metadata,
+                      retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
         return retryStrategy.retry {
-            guard let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/metadata") else {
+            guard let url = URL.PushNotifications.metadata(instanceId: instanceId,
+                                                           deviceId: deviceId) else {
                 return .failure(.genericError(reason: "Error while constructing the URL."))
             }
 
@@ -127,9 +153,13 @@ class NetworkService: PushNotificationsNetworkable {
         }
     }
 
-    func setUserId(instanceId: String, deviceId: String, token: String, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
+    func setUserId(instanceId: String,
+                   deviceId: String,
+                   token: String,
+                   retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
         return retryStrategy.retry {
-            guard let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/user") else {
+            guard let url = URL.PushNotifications.user(instanceId: instanceId,
+                                                       deviceId: deviceId) else {
                 return .failure(.genericError(reason: "Error while constructing the URL."))
             }
 
@@ -144,9 +174,12 @@ class NetworkService: PushNotificationsNetworkable {
         }
     }
 
-    func deleteDevice(instanceId: String, deviceId: String, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
+    func deleteDevice(instanceId: String,
+                      deviceId: String,
+                      retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
         return retryStrategy.retry {
-            guard let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)") else {
+            guard let url = URL.PushNotifications.device(instanceId: instanceId,
+                                                         deviceId: deviceId) else {
                 return .failure(.genericError(reason: "Error while constructing the URL."))
             }
 
@@ -160,9 +193,12 @@ class NetworkService: PushNotificationsNetworkable {
         }
     }
 
-    func getDevice(instanceId: String, deviceId: String, retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
+    func getDevice(instanceId: String,
+                   deviceId: String,
+                   retryStrategy: RetryStrategy) -> Result<Void, PushNotificationsAPIError> {
         return retryStrategy.retry {
-            guard let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)") else {
+            guard let url = URL.PushNotifications.device(instanceId: instanceId,
+                                                         deviceId: deviceId) else {
                 return .failure(.genericError(reason: "Error while constructing the URL."))
             }
 
@@ -177,7 +213,9 @@ class NetworkService: PushNotificationsNetworkable {
     }
 
     // MARK: Networking Layer
-    private func networkRequest(_ request: URLRequest, session: URLSession, retryStrategy: RetryStrategy) -> Result<Data, PushNotificationsAPIError> {
+    private func networkRequest(_ request: URLRequest,
+                                session: URLSession,
+                                retryStrategy: RetryStrategy) -> Result<Data, PushNotificationsAPIError> {
         let semaphore = DispatchSemaphore(value: 0)
         var result: Result<Data, PushNotificationsAPIError>?
 

--- a/Tests/Integration/TestAPIClientHelper.swift
+++ b/Tests/Integration/TestAPIClientHelper.swift
@@ -17,7 +17,9 @@ struct TestAPIClientHelper {
         let semaphore = DispatchSemaphore(value: 0)
         var interests: Interests?
 
-        let request = setRequest(url: URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/interests")!, httpMethod: .GET)
+        let request = setRequest(url: URL.PushNotifications.interests(instanceId: instanceId,
+                                                                      deviceId: deviceId)!,
+                                 httpMethod: .GET)
         session.dataTask(with: request) { (data, _, _) in
             interests = try? JSONDecoder().decode(Interests.self, from: data!)
             semaphore.signal()
@@ -31,7 +33,9 @@ struct TestAPIClientHelper {
         let session = URLSession.init(configuration: .ephemeral)
         let semaphore = DispatchSemaphore(value: 0)
 
-        let request = setRequest(url: URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)")!, httpMethod: .DELETE)
+        let request = setRequest(url: URL.PushNotifications.device(instanceId: instanceId,
+                                                                   deviceId: deviceId)!,
+                                 httpMethod: .DELETE)
         session.dataTask(with: request) { (_, _, _) in
             semaphore.signal()
         }.resume()
@@ -44,7 +48,9 @@ struct TestAPIClientHelper {
         let semaphore = DispatchSemaphore(value: 0)
         var device: TestDevice?
 
-        let request = setRequest(url: URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)")!, httpMethod: .GET)
+        let request = setRequest(url: URL.PushNotifications.device(instanceId: instanceId,
+                                                                   deviceId: deviceId)!,
+                                 httpMethod: .GET)
         session.dataTask(with: request) { (data, _, _) in
             device = try? JSONDecoder().decode(TestDevice.self, from: data!)
             semaphore.signal()

--- a/Tests/Unit/Services/ServerSyncProcessHandlerTests.swift
+++ b/Tests/Unit/Services/ServerSyncProcessHandlerTests.swift
@@ -31,7 +31,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
     }
 
     func testStartJob() {
-        let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let url = URL.PushNotifications.devices(instanceId: instanceId)!
         let exp = expectation(description: "It should successfully register the device")
 
         stub(condition: isMethodPOST() && isAbsoluteURLString(url.absoluteString)) { _ in
@@ -53,7 +53,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
     }
 
     func testStartJobRetriesDeviceCreation() {
-        let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let url = URL.PushNotifications.devices(instanceId: instanceId)!
         let exp = expectation(description: "It should successfully register the device")
 
         var numberOfAttempts = 0
@@ -112,7 +112,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
     }
 
     func testItShouldMergeTheRemoteInitialInterestsSetWithLocalInterestSet() {
-        let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let url = URL.PushNotifications.devices(instanceId: instanceId)!
 
         stub(condition: isMethodPOST() && isAbsoluteURLString(url.absoluteString)) { _ in
             let jsonObject: [String: Any] = [
@@ -159,7 +159,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
     }
 
     func testItShouldMergeTheRemoteInitialInterestsSetWithLocalInterestSetThisTimeUsingSetSubscriptions() {
-        let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let url = URL.PushNotifications.devices(instanceId: instanceId)!
 
         stub(condition: isMethodPOST() && isAbsoluteURLString(url.absoluteString)) { _ in
             let jsonObject: [String: Any] = [
@@ -192,7 +192,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
     }
 
     func testItShouldSetSubscriptionsAfterStartingIfItDiffersFromTheInitialInterestSet() {
-        let registerURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let registerURL = URL.PushNotifications.devices(instanceId: instanceId)!
 
         stub(condition: isMethodPOST() && isAbsoluteURLString(registerURL.absoluteString)) { _ in
             let jsonObject: [String: Any] = [
@@ -204,7 +204,8 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         }
 
         let exp = expectation(description: "It should successfully set subscriptions")
-        let setInterestsURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(self.deviceId)/interests")!
+        let setInterestsURL = URL.PushNotifications.interests(instanceId: instanceId,
+                                                              deviceId: deviceId)!
         stub(condition: isMethodPUT() && isAbsoluteURLString(setInterestsURL.absoluteString)) { _ in
             exp.fulfill()
             return HTTPStubsResponse(jsonObject: [], statusCode: 200, headers: nil)
@@ -234,7 +235,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
     }
 
     func testItShouldNotSetSubscriptionsAfterStartingIfItDoesntDifferFromTheInitialInterestSet() {
-        let registerURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let registerURL = URL.PushNotifications.devices(instanceId: instanceId)!
 
         stub(condition: isMethodPOST() && isAbsoluteURLString(registerURL.absoluteString)) { _ in
             let jsonObject: [String: Any] = [
@@ -247,7 +248,8 @@ class ServerSyncProcessHandlerTests: XCTestCase {
 
         let exp = expectation(description: "It should not call set subscriptions")
         exp.isInverted = true
-        let setInterestsURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(self.deviceId)/interests")!
+        let setInterestsURL = URL.PushNotifications.interests(instanceId: instanceId,
+                                                              deviceId: deviceId)!
         stub(condition: isMethodPUT() && isAbsoluteURLString(setInterestsURL.absoluteString)) { _ in
             exp.fulfill()
             return HTTPStubsResponse(jsonObject: [], statusCode: 200, headers: nil)
@@ -272,7 +274,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
     }
 
     func testStopJobBeforeStartSHouldNotThrowAnError() {
-        let registerURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let registerURL = URL.PushNotifications.devices(instanceId: instanceId)!
 
         stub(condition: isMethodPOST() && isAbsoluteURLString(registerURL.absoluteString)) { _ in
             let jsonObject: [String: Any] = [
@@ -296,7 +298,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
     }
 
     func testStopJobWillDeleteDeviceRemotelyAndLocally() {
-        let registerURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let registerURL = URL.PushNotifications.devices(instanceId: instanceId)!
 
         stub(condition: isMethodPOST() && isAbsoluteURLString(registerURL.absoluteString)) { _ in
             let jsonObject: [String: Any] = [
@@ -307,7 +309,8 @@ class ServerSyncProcessHandlerTests: XCTestCase {
             return HTTPStubsResponse(jsonObject: jsonObject, statusCode: 200, headers: nil)
         }
 
-        let deleteURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)")!
+        let deleteURL = URL.PushNotifications.device(instanceId: instanceId,
+                                                     deviceId: deviceId)!
 
         stub(condition: isAbsoluteURLString(deleteURL.absoluteString)) { _ in
             return HTTPStubsResponse(jsonObject: [], statusCode: 200, headers: nil)
@@ -330,7 +333,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
     }
 
     func testThatSubscribingUnsubscribingAndSetSubscriptionsWillTriggerTheAPI() {
-        let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let url = URL.PushNotifications.devices(instanceId: instanceId)!
         var expRegisterCalled = false
         var expSubscribeCalled = false
         var expUnsubscribeCalled = false
@@ -346,19 +349,24 @@ class ServerSyncProcessHandlerTests: XCTestCase {
             return HTTPStubsResponse(jsonObject: jsonObject, statusCode: 200, headers: nil)
         }
 
-        let addInterestURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(self.deviceId)/interests/hello")!
+        let addInterestURL = URL.PushNotifications.interest(instanceId: instanceId,
+                                                            deviceId: deviceId,
+                                                            interest: "hello")!
         stub(condition: isMethodPOST() && isAbsoluteURLString(addInterestURL.absoluteString)) { _ in
             expSubscribeCalled = true
             return HTTPStubsResponse(jsonObject: [], statusCode: 200, headers: nil)
         }
 
-        let removeInterestURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(self.deviceId)/interests/hello")!
+        let removeInterestURL = URL.PushNotifications.interest(instanceId: instanceId,
+                                                               deviceId: deviceId,
+                                                               interest: "hello")!
         stub(condition: isMethodDELETE() && isAbsoluteURLString(removeInterestURL.absoluteString)) { _ in
             expUnsubscribeCalled = true
             return HTTPStubsResponse(jsonObject: [], statusCode: 200, headers: nil)
         }
 
-        let setSubscriptionsURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(self.deviceId)/interests")!
+        let setSubscriptionsURL = URL.PushNotifications.interests(instanceId: instanceId,
+                                                                  deviceId: deviceId)!
         stub(condition: isMethodPUT() && isAbsoluteURLString(setSubscriptionsURL.absoluteString)) { _ in
             expSetSubscriptionsCalled = true
             return HTTPStubsResponse(jsonObject: [], statusCode: 200, headers: nil)
@@ -384,7 +392,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
     }
 
     func testDeviceRecreation() {
-        let registerURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let registerURL = URL.PushNotifications.devices(instanceId: instanceId)!
 
         let newDeviceId = "new-device-id"
         var isFirstTimeRegistering = true
@@ -402,12 +410,16 @@ class ServerSyncProcessHandlerTests: XCTestCase {
             return HTTPStubsResponse(jsonObject: jsonObject, statusCode: 200, headers: nil)
         }
 
-        let subscribeURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/interests/hello")!
+        let subscribeURL = URL.PushNotifications.interest(instanceId: instanceId,
+                                                          deviceId: deviceId,
+                                                          interest: "hello")!
         stub(condition: isMethodPOST() && isAbsoluteURLString(subscribeURL.absoluteString)) { _ in
             return HTTPStubsResponse(jsonObject: [], statusCode: 404, headers: nil)
         }
 
-        let subscribe2URL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(newDeviceId)/interests/hello")!
+        let subscribe2URL = URL.PushNotifications.interest(instanceId: instanceId,
+                                                           deviceId: newDeviceId,
+                                                           interest: "hello")!
         stub(condition: isMethodPOST() && isAbsoluteURLString(subscribe2URL.absoluteString)) { _ in
             return HTTPStubsResponse(jsonObject: [], statusCode: 200, headers: nil)
         }
@@ -428,7 +440,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
     }
 
     func testDeviceRecreationShouldClearPreviousUserIdIfTokenProviderIsMissing() {
-        let registerURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let registerURL = URL.PushNotifications.devices(instanceId: instanceId)!
 
         let newDeviceId = "new-device-id"
         var isFirstTimeRegistering = true
@@ -446,12 +458,16 @@ class ServerSyncProcessHandlerTests: XCTestCase {
             return HTTPStubsResponse(jsonObject: jsonObject, statusCode: 200, headers: nil)
         }
 
-        let subscribeURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/interests/hello")!
+        let subscribeURL = URL.PushNotifications.interest(instanceId: instanceId,
+                                                          deviceId: deviceId,
+                                                          interest: "hello")!
         stub(condition: isMethodPOST() && isAbsoluteURLString(subscribeURL.absoluteString)) { _ in
             return HTTPStubsResponse(jsonObject: [], statusCode: 404, headers: nil)
         }
 
-        let subscribe2URL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(newDeviceId)/interests/hello")!
+        let subscribe2URL = URL.PushNotifications.interest(instanceId: instanceId,
+                                                           deviceId: newDeviceId,
+                                                           interest: "hello")!
         stub(condition: isMethodPOST() && isAbsoluteURLString(subscribe2URL.absoluteString)) { _ in
             return HTTPStubsResponse(jsonObject: [], statusCode: 200, headers: nil)
         }
@@ -476,7 +492,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
     }
 
     func testMetadataSynchonizationWhenAppStarts() {
-        let registerURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let registerURL = URL.PushNotifications.devices(instanceId: instanceId)!
         stub(condition: isMethodPOST() && isAbsoluteURLString(registerURL.absoluteString)) { _ in
             let jsonObject: [String: Any] = [
                 "id": self.deviceId
@@ -485,13 +501,14 @@ class ServerSyncProcessHandlerTests: XCTestCase {
             return HTTPStubsResponse(jsonObject: jsonObject, statusCode: 200, headers: nil)
         }
 
-        let deleteURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)")!
+        let deleteURL = URL.PushNotifications.device(instanceId: instanceId,
+                                                     deviceId: deviceId)!
         stub(condition: isAbsoluteURLString(deleteURL.absoluteString)) { _ in
             return HTTPStubsResponse(jsonObject: [], statusCode: 200, headers: nil)
         }
 
         var numMetadataCalled = 0
-        let metadataURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/metadata")!
+        let metadataURL = URL.PushNotifications.metadata(instanceId: instanceId, deviceId: deviceId)!
         stub(condition: isMethodPUT() && isAbsoluteURLString(metadataURL.absoluteString)) { _ in
             numMetadataCalled += 1
             return HTTPStubsResponse(jsonObject: [], statusCode: 200, headers: nil)
@@ -528,7 +545,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
     }
 
     func testInterestsSynchonizationWhenAppStarts() {
-        let registerURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let registerURL = URL.PushNotifications.devices(instanceId: instanceId)!
         stub(condition: isMethodPOST() && isAbsoluteURLString(registerURL.absoluteString)) { _ in
             let jsonObject: [String: Any] = [
                 "id": self.deviceId
@@ -537,13 +554,14 @@ class ServerSyncProcessHandlerTests: XCTestCase {
             return HTTPStubsResponse(jsonObject: jsonObject, statusCode: 200, headers: nil)
         }
 
-        let deleteURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)")!
+        let deleteURL = URL.PushNotifications.device(instanceId: instanceId,
+                                                     deviceId: deviceId)!
         stub(condition: isAbsoluteURLString(deleteURL.absoluteString)) { _ in
             return HTTPStubsResponse(jsonObject: [], statusCode: 200, headers: nil)
         }
 
         var numInterestsCalled = 0
-        let setInterestsURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/interests")!
+        let setInterestsURL = URL.PushNotifications.interests(instanceId: instanceId, deviceId: deviceId)!
         stub(condition: isMethodPUT() && isAbsoluteURLString(setInterestsURL.absoluteString)) { _ in
             numInterestsCalled += 1
             return HTTPStubsResponse(jsonObject: [], statusCode: 200, headers: nil)
@@ -580,7 +598,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
     }
 
     func testSetUserIdAfterStartShouldSetTheUserIdInTheServerAndLocalStorage() {
-        let registerURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let registerURL = URL.PushNotifications.devices(instanceId: instanceId)!
         stub(condition: isMethodPOST() && isAbsoluteURLString(registerURL.absoluteString)) { _ in
             let jsonObject: [String: Any] = [
                 "id": self.deviceId
@@ -601,7 +619,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         serverSyncProcessHandler.handleMessage(serverSyncJob: startJob)
 
         let exp = expectation(description: "Set user id will be called in the server")
-        let setUserIdURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/user")!
+        let setUserIdURL = URL.PushNotifications.user(instanceId: instanceId, deviceId: deviceId)!
         stub(condition: isMethodPUT() && isAbsoluteURLString(setUserIdURL.absoluteString)) { _ in
             exp.fulfill()
             return HTTPStubsResponse(jsonObject: [], statusCode: 200, headers: nil)
@@ -616,7 +634,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
     }
 
     func testSetUserIdSuccessCallbackIsCalled() {
-        let registerURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let registerURL = URL.PushNotifications.devices(instanceId: instanceId)!
         stub(condition: isMethodPOST() && isAbsoluteURLString(registerURL.absoluteString)) { _ in
             let jsonObject: [String: Any] = [
                 "id": self.deviceId
@@ -646,7 +664,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         serverSyncProcessHandler.jobQueue.append(startJob)
         serverSyncProcessHandler.handleMessage(serverSyncJob: startJob)
 
-        let setUserIdURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/user")!
+        let setUserIdURL = URL.PushNotifications.user(instanceId: instanceId, deviceId: deviceId)!
         stub(condition: isMethodPUT() && isAbsoluteURLString(setUserIdURL.absoluteString)) { _ in
             return HTTPStubsResponse(jsonObject: [], statusCode: 200, headers: nil)
         }
@@ -658,7 +676,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
     }
 
     func testSetUserIdTokenProviderNilError() {
-        let registerURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let registerURL = URL.PushNotifications.devices(instanceId: instanceId)!
         stub(condition: isMethodPOST() && isAbsoluteURLString(registerURL.absoluteString)) { _ in
             let jsonObject: [String: Any] = [
                 "id": self.deviceId
@@ -688,7 +706,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         serverSyncProcessHandler.jobQueue.append(startJob)
         serverSyncProcessHandler.handleMessage(serverSyncJob: startJob)
 
-        let setUserIdURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/user")!
+        let setUserIdURL = URL.PushNotifications.user(instanceId: instanceId, deviceId: deviceId)!
         stub(condition: isMethodPUT() && isAbsoluteURLString(setUserIdURL.absoluteString)) { _ in
             return HTTPStubsResponse(jsonObject: [], statusCode: 200, headers: nil)
         }
@@ -700,7 +718,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
     }
 
     func testSetUserIdTokenProviderReturnsError() {
-        let registerURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let registerURL = URL.PushNotifications.devices(instanceId: instanceId)!
         stub(condition: isMethodPOST() && isAbsoluteURLString(registerURL.absoluteString)) { _ in
             let jsonObject: [String: Any] = [
                 "id": self.deviceId
@@ -731,7 +749,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         serverSyncProcessHandler.jobQueue.append(startJob)
         serverSyncProcessHandler.handleMessage(serverSyncJob: startJob)
 
-        let setUserIdURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/user")!
+        let setUserIdURL = URL.PushNotifications.user(instanceId: instanceId, deviceId: deviceId)!
         stub(condition: isMethodPUT() && isAbsoluteURLString(setUserIdURL.absoluteString)) { _ in
             return HTTPStubsResponse(jsonObject: [], statusCode: 200, headers: nil)
         }
@@ -743,7 +761,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
     }
 
     func testSetUserIdBeamsServerRejectsTheRequest() {
-        let registerURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let registerURL = URL.PushNotifications.devices(instanceId: instanceId)!
         stub(condition: isMethodPOST() && isAbsoluteURLString(registerURL.absoluteString)) { _ in
             let jsonObject: [String: Any] = [
                 "id": self.deviceId
@@ -774,7 +792,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         serverSyncProcessHandler.jobQueue.append(startJob)
         serverSyncProcessHandler.handleMessage(serverSyncJob: startJob)
 
-        let setUserIdURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/user")!
+        let setUserIdURL = URL.PushNotifications.user(instanceId: instanceId, deviceId: deviceId)!
         stub(condition: isMethodPUT() && isAbsoluteURLString(setUserIdURL.absoluteString)) { _ in
             return HTTPStubsResponse(jsonObject: [], statusCode: 400, headers: nil)
         }
@@ -786,7 +804,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
     }
 
     func testSetUserIdTokenProviderThrowsException() {
-        let registerURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let registerURL = URL.PushNotifications.devices(instanceId: instanceId)!
         stub(condition: isMethodPOST() && isAbsoluteURLString(registerURL.absoluteString)) { _ in
             let jsonObject: [String: Any] = [
                 "id": self.deviceId
@@ -817,7 +835,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
         serverSyncProcessHandler.jobQueue.append(startJob)
         serverSyncProcessHandler.handleMessage(serverSyncJob: startJob)
 
-        let setUserIdURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns/\(deviceId)/user")!
+        let setUserIdURL = URL.PushNotifications.user(instanceId: instanceId, deviceId: deviceId)!
         stub(condition: isMethodPUT() && isAbsoluteURLString(setUserIdURL.absoluteString)) { _ in
             return HTTPStubsResponse(jsonObject: [], statusCode: 200, headers: nil)
         }
@@ -830,7 +848,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
 
     #if os(iOS)
     func testTrackWillSendEventTypeToTheServer() {
-        let url = URL(string: "https://\(instanceId).pushnotifications.pusher.com/device_api/v1/instances/\(instanceId)/devices/apns")!
+        let url = URL.PushNotifications.devices(instanceId: instanceId)!
         var expRegisterCalled = false
         var trackCalled = false
 
@@ -844,7 +862,7 @@ class ServerSyncProcessHandlerTests: XCTestCase {
             return HTTPStubsResponse(jsonObject: jsonObject, statusCode: 200, headers: nil)
         }
 
-        let trackURL = URL(string: "https://\(instanceId).pushnotifications.pusher.com/reporting_api/v2/instances/\(instanceId)/events")!
+        let trackURL = URL.PushNotifications.events(instanceId: instanceId)!
         stub(condition: isMethodPOST() && isAbsoluteURLString(trackURL.absoluteString)) { _ in
             trackCalled = true
             return HTTPStubsResponse(jsonObject: [], statusCode: 200, headers: nil)


### PR DESCRIPTION
This PR:

- Improves the maintainability of `NetworkService` and the associated `ServerSyncProcessHandlerTests` by refactoring to avoid repeated String literals.
