### PR TITLE
Remove redundant `public` API

### DIFF
--- a/Sources/Helpers/MD5.swift
+++ b/Sources/Helpers/MD5.swift
@@ -19,13 +19,11 @@
 
 import Foundation
 
-// MARK: - Public
-
-public func MD5(_ input: String) -> String {
-  return hex_md5(input)
-}
-
 // MARK: - Functions
+
+func MD5(_ input: String) -> String {
+    return hex_md5(input)
+}
 
 func hex_md5(_ input: String) -> String {
   return rstr2hex(rstr_md5(str2rstr_utf8(input)))

--- a/Sources/Models/Metadata.swift
+++ b/Sources/Models/Metadata.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Metadata: Equatable, Codable {
+struct Metadata: Equatable, Codable {
     let sdkVersion: String?
     let iosVersion: String?
     let macosVersion: String?

--- a/Sources/Protocols/RetryStrategy.swift
+++ b/Sources/Protocols/RetryStrategy.swift
@@ -4,7 +4,7 @@ protocol RetryStrategy {
     func retry<T>(function: () -> Result<T, PushNotificationsAPIError>) -> Result<T, PushNotificationsAPIError>
 }
 
-public struct JustDont: RetryStrategy {
+struct JustDont: RetryStrategy {
     func retry<T>(function: () -> Result<T, PushNotificationsAPIError>) -> Result<T, PushNotificationsAPIError> {
         let result = function()
 
@@ -19,7 +19,7 @@ public struct JustDont: RetryStrategy {
     }
 }
 
-public class WithInfiniteExpBackoff: RetryStrategy {
+class WithInfiniteExpBackoff: RetryStrategy {
     private var retryCount = 0
 
     func retry<T>(function: () -> Result<T, PushNotificationsAPIError>) -> Result<T, PushNotificationsAPIError> {

--- a/Sources/Services/DeviceStateStore.swift
+++ b/Sources/Services/DeviceStateStore.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public class DeviceStateStore {
+class DeviceStateStore {
 
     let service: UserDefaults
 
@@ -96,7 +96,7 @@ public class DeviceStateStore {
     }
 }
 
-public class InstanceDeviceStateStore {
+class InstanceDeviceStateStore {
     static let queue = DispatchQueue(label: "com.pusher.beams.deviceStateStoreQueue")
     let service: UserDefaults
     let instanceId: String?


### PR DESCRIPTION
This PR:

- Removes redundant `public` API types and methods
  - I.e. These types and methods are not used by any other public API, so can be safely marked as `internal`
