### PR TITLE
Add SwiftLint as a non-target SPM dependency

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,5 @@
 excluded:
+  - .build
   - Sources/Helpers/MD5.swift # this dependency will be removed in the future version of the SDK
   - Carthage
   - Package.swift

--- a/Package.resolved
+++ b/Package.resolved
@@ -36,6 +36,60 @@
           "revision": "12f19662426d0434d6c330c6974d53e2eb10ecd9",
           "version": "9.1.0"
         }
+      },
+      {
+        "package": "SourceKitten",
+        "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
+        "state": {
+          "branch": null,
+          "revision": "7f4be006fe73211b0fd9666c73dc2f2303ffa756",
+          "version": "0.31.0"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
+        "state": {
+          "branch": null,
+          "revision": "9564d61b08a5335ae0a36f789a7d71493eacadfc",
+          "version": "0.3.2"
+        }
+      },
+      {
+        "package": "SwiftLint",
+        "repositoryURL": "https://github.com/realm/SwiftLint",
+        "state": {
+          "branch": null,
+          "revision": "180d94132758dd183124ab1e63d6aa8e10023ec2",
+          "version": "0.43.1"
+        }
+      },
+      {
+        "package": "SwiftyTextTable",
+        "repositoryURL": "https://github.com/scottrhoyt/SwiftyTextTable.git",
+        "state": {
+          "branch": null,
+          "revision": "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+          "version": "0.9.0"
+        }
+      },
+      {
+        "package": "SWXMLHash",
+        "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
+        "state": {
+          "branch": null,
+          "revision": "9183170d20857753d4f331b0ca63f73c60764bf3",
+          "version": "5.0.2"
+        }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams.git",
+        "state": {
+          "branch": null,
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
+        }
       }
     ]
   },

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,9 @@ let package = Package(name: "PushNotifications",
                                  .upToNextMajor(from: "9.0.0")),
                         .package(url: "https://github.com/AliSoftware/OHHTTPStubs",
                                  .upToNextMajor(from: "9.1.0")),
+                        // Source code linting
+                        .package(url: "https://github.com/realm/SwiftLint",
+                                 .upToNextMajor(from: "0.43.1"))
                       ],
                       targets: [
                         .target(name: "PushNotifications",


### PR DESCRIPTION
This PR:

- Adds SwiftLint as a non-target SPM dependency
  - Useful for local linting during development when working on the Package directly (rather than via the Xcode workspace)