### PR TITLE
Implemented additional retry strategy for a "Could not create device"…

### DIFF
--- a/Sources/Models/PushNotificationsAPIError.swift
+++ b/Sources/Models/PushNotificationsAPIError.swift
@@ -6,6 +6,7 @@ enum PushNotificationsAPIError: Error, CustomDebugStringConvertible {
     case badJWT(reason: String)
     case genericError(reason: String)
     case badDeviceToken(reason: String)
+    case couldNotCreateDevice
 
     var debugDescription: String {
         switch self {
@@ -19,6 +20,8 @@ enum PushNotificationsAPIError: Error, CustomDebugStringConvertible {
             return "Error: \(reason)"
         case .badDeviceToken(let reason):
             return "Bad Device Token: \(reason)"
+        case .couldNotCreateDevice:
+            return "Device could not be created"
         }
     }
 }

--- a/Sources/Protocols/RetryStrategy.swift
+++ b/Sources/Protocols/RetryStrategy.swift
@@ -29,7 +29,7 @@ class WithInfiniteExpBackoff: RetryStrategy {
             switch result {
             case .failure(let error):
                 switch error {
-                case .deviceNotFound, .badRequest, .badJWT, .badDeviceToken:
+                case .deviceNotFound, .badRequest, .badJWT, .badDeviceToken, .couldNotCreateDevice:
                     // Not recoverable cases.
                     return result
 

--- a/Sources/Services/NetworkService.swift
+++ b/Sources/Services/NetworkService.swift
@@ -270,7 +270,11 @@ class NetworkService: PushNotificationsNetworkable {
             default:
                 let reason = try? JSONDecoder().decode(Reason.self, from: data)
 
-                result = .failure(.genericError(reason: reason?.description  ?? "Unknown API error"))
+                if reason?.description.elementsEqual("Device could not be created") ?? false {
+                    result = .failure(.couldNotCreateDevice)
+                } else {
+                    result = .failure(.genericError(reason: reason?.description  ?? "Unknown API error"))
+                }
             }
 
             semaphore.signal()


### PR DESCRIPTION
… API response, and test for this.

### What?
Adds an extra retry case (and test) for our server sending a "Could not create device" error message, so that it follows the same retry strategy as the other unrecoverable cases (such as badDeviceToken, badJWT, or deviceNotFound). Currently it retries forever with exponential backoff, but this isn't a network error, so it isn't recoverable.
...

#### Why?
A customer has a case where the above error message was making his client infinitely retry.
...
