### PR TITLE
added getter for UserId

### DIFF
--- a/Sources/PushNotifications.swift
+++ b/Sources/PushNotifications.swift
@@ -152,6 +152,18 @@ import Foundation
         }
         self.serverSyncHandler.sendMessage(serverSyncJob: .setUserIdJob(userId: userId))
     }
+    
+    /**
+     Get the UserId that the device is currently authenticated to.
+     
+     - returns: string of UserId
+     */
+    /// - Tag: getUserId
+    @objc public func getUserId() -> String? {
+        return InstanceDeviceStateStore.synchronize {
+            return self.deviceStateStore.getUserId()
+        }
+    }
 
     @objc private func printHelpfulMessage() {
         print("[PushNotifications] - It looks like setUserId hasn't completed yet -- have you called `registerDeviceToken`?")

--- a/Sources/PushNotificationsStatic.swift
+++ b/Sources/PushNotificationsStatic.swift
@@ -106,7 +106,20 @@ import Foundation
             fatalError("PushNotifications.shared.start must have been called first")
         }
     }
-
+    
+    /**
+     Get the UserId that the device is currently authenticated to.
+     
+     - returns: string of UserId
+     */
+    /// - Tag: getUserId
+    @objc public static func getUserId() -> String? {
+        if let staticInstance = instance {
+            return staticInstance.getUserId()
+        } else {
+            fatalError("PushNotifications.shared.start must have been called first")
+        }
+    }
     /**
      Disable Beams service.
      


### PR DESCRIPTION
### What?

Added a getter for the UserId

#### Why?

A couple of users are using setUserId() to ensure that the device is authenticated, but this is causing odd issues with crashes and strange responses from the api, plus its an unnecessary request, and this method is already in the Beams Web sdk